### PR TITLE
Feature/#103 levelup

### DIFF
--- a/src/main/java/com/springles/controller/api/MemberController.java
+++ b/src/main/java/com/springles/controller/api/MemberController.java
@@ -175,4 +175,20 @@ public class MemberController {
                         .build()
         );
     }
+
+    @PatchMapping("/levelup")
+    public ResponseEntity<ResResult> levelUp(
+            @RequestHeader(value = "Authorization") String authHeader
+    ) {
+        ResponseCode responseCode = ResponseCode.MEMBER_LEVEL_UP;
+
+        return ResponseEntity.ok(
+                ResResult.builder()
+                        .responseCode(responseCode)
+                        .code(responseCode.getCode())
+                        .message(responseCode.getMessage())
+                        .data(memberService.levelUp(authHeader))
+                        .build()
+        );
+    }
 }

--- a/src/main/java/com/springles/controller/api/MemberController.java
+++ b/src/main/java/com/springles/controller/api/MemberController.java
@@ -178,7 +178,8 @@ public class MemberController {
 
     @PatchMapping("/levelup")
     public ResponseEntity<ResResult> levelUp(
-            @RequestHeader(value = "Authorization") String authHeader
+            // 테스트를 위해 param으로 받음 -> 추후 @RequestParam 삭제 필요
+            @RequestParam("memberId") Long memberId
     ) {
         ResponseCode responseCode = ResponseCode.MEMBER_LEVEL_UP;
 
@@ -187,7 +188,7 @@ public class MemberController {
                         .responseCode(responseCode)
                         .code(responseCode.getCode())
                         .message(responseCode.getMessage())
-                        .data(memberService.levelUp(authHeader))
+                        .data(memberService.levelUp(memberId))
                         .build()
         );
     }

--- a/src/main/java/com/springles/domain/constants/GameRole.java
+++ b/src/main/java/com/springles/domain/constants/GameRole.java
@@ -1,7 +1,9 @@
 package com.springles.domain.constants;
 
+import lombok.Getter;
 import lombok.val;
 
+@Getter
 public enum GameRole {
     MAFIA("mafia"),
     CIVILIAN("civilian"),

--- a/src/main/java/com/springles/domain/constants/Level.java
+++ b/src/main/java/com/springles/domain/constants/Level.java
@@ -9,7 +9,8 @@ public enum Level {
     SOLDIER(2L, 3000L, "SOLDIER"),
     CAPTAIN(3L, 6000L, "CAPTAIN"),
     UNDERBOSS(4L, 10000L, "UNDER BOSS"),
-    BOSS(5L, 100000L, "BOSS");
+    BOSS(5L, 0L, "BOSS"),
+    NONE(6L,0L,"NONE");
 
     private Long val;
     private Long goalExp;

--- a/src/main/java/com/springles/domain/constants/Level.java
+++ b/src/main/java/com/springles/domain/constants/Level.java
@@ -1,0 +1,23 @@
+package com.springles.domain.constants;
+
+import lombok.Getter;
+
+@Getter
+public enum Level {
+    BEGINNER(0L, 200L, "BEGINNER"),
+    ASSOCIATE(1L, 1000L, "ASSOCIATE"),
+    SOLDIER(2L, 3000L, "SOLDIER"),
+    CAPTAIN(3L, 6000L, "CAPTAIN"),
+    UNDERBOSS(4L, 10000L, "UNDER BOSS"),
+    BOSS(5L, 100000L, "BOSS");
+
+    private Long val;
+    private Long goalExp;
+    private String name;
+
+    Level(Long val, Long goalExp, String name) {
+        this.val = val;
+        this.goalExp = goalExp;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/springles/domain/constants/ResponseCode.java
+++ b/src/main/java/com/springles/domain/constants/ResponseCode.java
@@ -29,6 +29,7 @@ public enum ResponseCode {
     MEMBER_PROFILE_CREATE(HttpStatus.OK,"200","프로필 설정 완료"),
     MEMBER_PROFILE_UPDATE(HttpStatus.OK,"200","프로필 수정 완료"),
     MEMBER_PROFILE_READ(HttpStatus.OK,"200","프로필 조회 완료"),
+    MEMBER_LEVEL_UP(HttpStatus.OK,"200","경험치 증가 완료"),
 
     /* CHATROOM */
     CHATROOM_SEARCH(HttpStatus.OK,"200","채팅방 목록 조회 성공"),

--- a/src/main/java/com/springles/domain/dto/game/VoteDto.java
+++ b/src/main/java/com/springles/domain/dto/game/VoteDto.java
@@ -1,36 +1,36 @@
-//package com.springles.domain.dto.game;
-//
-//import com.springles.domain.entity.Vote;
-//import lombok.Builder;
-//import lombok.Getter;
-//import org.springframework.data.redis.core.index.Indexed;
-//
-//@Builder
-//@Getter
-//public class VoteDto {
-//    private Long voteId;
-//    private Long roomId; // 방 넘버로 조회 가능
-//    private Long stageId; // 한 게임 안에서 몇 번째 투표인지로 조회 가능
-//    private Long voter; // 투표를 한 사람 PlayerID
-//    private Long election; // 투표를 당한 사람 PlaterID
-//    private String voteCase;
-//
-//    public static VoteDto fromEntity(Vote vote) {
-//        return VoteDto.builder()
-//                .roomId(vote.getRoomId())
-//                .stageId(vote.getStageId())
-//                .voter(vote.getVoter())
-//                .election(vote.getElection())
-//                .voteCase(vote.getVoteCase()).build();
-//    }
-//
-//    public static Vote createVote(VoteDto voteDto) {
-//        return Vote.builder()
-//                .roomId(voteDto.getRoomId())
-//                .stageId(voteDto.getStageId())
-//                .voter(voteDto.getVoter())
-//                .election(voteDto.getElection())
-//                .voteCase(voteDto.getVoteCase())
-//                .build();
-//    }
-//}
+package com.springles.domain.dto.game;
+
+import com.springles.domain.entity.Vote;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Builder
+@Getter
+public class VoteDto {
+    private Long voteId;
+    private Long roomId; // 방 넘버로 조회 가능
+    private Long stageId; // 한 게임 안에서 몇 번째 투표인지로 조회 가능
+    private Long voter; // 투표를 한 사람 PlayerID
+    private Long election; // 투표를 당한 사람 PlaterID
+    private String voteCase;
+
+    public static VoteDto fromEntity(Vote vote) {
+        return VoteDto.builder()
+                .roomId(vote.getRoomId())
+                .stageId(vote.getStageId())
+                .voter(vote.getVoter())
+                .election(vote.getElection())
+                .voteCase(vote.getVoteCase()).build();
+    }
+
+    public static Vote createVote(VoteDto voteDto) {
+        return Vote.builder()
+                .roomId(voteDto.getRoomId())
+                .stageId(voteDto.getStageId())
+                .voter(voteDto.getVoter())
+                .election(voteDto.getElection())
+                .voteCase(voteDto.getVoteCase())
+                .build();
+    }
+}

--- a/src/main/java/com/springles/domain/dto/game/VoteDto.java
+++ b/src/main/java/com/springles/domain/dto/game/VoteDto.java
@@ -1,36 +1,36 @@
-package com.springles.domain.dto.game;
-
-import com.springles.domain.entity.Vote;
-import lombok.Builder;
-import lombok.Getter;
-import org.springframework.data.redis.core.index.Indexed;
-
-@Builder
-@Getter
-public class VoteDto {
-    private Long voteId;
-    private Long roomId; // 방 넘버로 조회 가능
-    private Long stageId; // 한 게임 안에서 몇 번째 투표인지로 조회 가능
-    private Long voter; // 투표를 한 사람 PlayerID
-    private Long election; // 투표를 당한 사람 PlaterID
-    private String voteCase;
-
-    public static VoteDto fromEntity(Vote vote) {
-        return VoteDto.builder()
-                .roomId(vote.getRoomId())
-                .stageId(vote.getStageId())
-                .voter(vote.getVoter())
-                .election(vote.getElection())
-                .voteCase(vote.getVoteCase()).build();
-    }
-
-    public static Vote createVote(VoteDto voteDto) {
-        return Vote.builder()
-                .roomId(voteDto.getRoomId())
-                .stageId(voteDto.getStageId())
-                .voter(voteDto.getVoter())
-                .election(voteDto.getElection())
-                .voteCase(voteDto.getVoteCase())
-                .build();
-    }
-}
+//package com.springles.domain.dto.game;
+//
+//import com.springles.domain.entity.Vote;
+//import lombok.Builder;
+//import lombok.Getter;
+//import org.springframework.data.redis.core.index.Indexed;
+//
+//@Builder
+//@Getter
+//public class VoteDto {
+//    private Long voteId;
+//    private Long roomId; // 방 넘버로 조회 가능
+//    private Long stageId; // 한 게임 안에서 몇 번째 투표인지로 조회 가능
+//    private Long voter; // 투표를 한 사람 PlayerID
+//    private Long election; // 투표를 당한 사람 PlaterID
+//    private String voteCase;
+//
+//    public static VoteDto fromEntity(Vote vote) {
+//        return VoteDto.builder()
+//                .roomId(vote.getRoomId())
+//                .stageId(vote.getStageId())
+//                .voter(vote.getVoter())
+//                .election(vote.getElection())
+//                .voteCase(vote.getVoteCase()).build();
+//    }
+//
+//    public static Vote createVote(VoteDto voteDto) {
+//        return Vote.builder()
+//                .roomId(voteDto.getRoomId())
+//                .stageId(voteDto.getStageId())
+//                .voter(voteDto.getVoter())
+//                .election(voteDto.getElection())
+//                .voteCase(voteDto.getVoteCase())
+//                .build();
+//    }
+//}

--- a/src/main/java/com/springles/domain/dto/member/MemberProfileCreateRequest.java
+++ b/src/main/java/com/springles/domain/dto/member/MemberProfileCreateRequest.java
@@ -1,5 +1,6 @@
 package com.springles.domain.dto.member;
 
+import com.springles.domain.constants.Level;
 import com.springles.domain.constants.ProfileImg;
 import com.springles.domain.entity.MemberGameInfo;
 import jakarta.validation.constraints.NotBlank;
@@ -45,7 +46,7 @@ public class MemberProfileCreateRequest {
         return MemberGameInfo.builder()
                 .nickname(memberDto.getNickname())
                 .profileImg(profileImg)
-                .level(0L)
+                .level(Level.BEGINNER)
                 .exp(0L)
                 .memberId(memberId)
                 .build();

--- a/src/main/java/com/springles/domain/dto/member/MemberProfileCreateRequest.java
+++ b/src/main/java/com/springles/domain/dto/member/MemberProfileCreateRequest.java
@@ -1,5 +1,6 @@
 package com.springles.domain.dto.member;
 
+import com.springles.domain.constants.GameRole;
 import com.springles.domain.constants.Level;
 import com.springles.domain.constants.ProfileImg;
 import com.springles.domain.entity.MemberGameInfo;
@@ -48,6 +49,7 @@ public class MemberProfileCreateRequest {
                 .profileImg(profileImg)
                 .level(Level.BEGINNER)
                 .exp(0L)
+                .inGameRole(GameRole.NONE)
                 .memberId(memberId)
                 .build();
     }

--- a/src/main/java/com/springles/domain/dto/member/MemberProfileRead.java
+++ b/src/main/java/com/springles/domain/dto/member/MemberProfileRead.java
@@ -1,5 +1,6 @@
 package com.springles.domain.dto.member;
 
+import com.springles.domain.constants.Level;
 import com.springles.domain.constants.ProfileImg;
 import com.springles.domain.entity.MemberGameInfo;
 import jakarta.validation.constraints.NotBlank;
@@ -18,7 +19,7 @@ public class MemberProfileRead {
 
     private String nickname;
     private ProfileImg profileImg;
-    private Long level;
+    private String level;
     private Long exp;
-    private Long nextLevel;
+    private String nextLevel;
 }

--- a/src/main/java/com/springles/domain/dto/member/MemberProfileRead.java
+++ b/src/main/java/com/springles/domain/dto/member/MemberProfileRead.java
@@ -22,4 +22,5 @@ public class MemberProfileRead {
     private String level;
     private Long exp;
     private String nextLevel;
+    private Long rank;
 }

--- a/src/main/java/com/springles/domain/dto/member/MemberProfileResponse.java
+++ b/src/main/java/com/springles/domain/dto/member/MemberProfileResponse.java
@@ -1,6 +1,7 @@
 package com.springles.domain.dto.member;
 
 import com.springles.domain.constants.GameRole;
+import com.springles.domain.constants.Level;
 import com.springles.domain.constants.ProfileImg;
 import com.springles.domain.entity.MemberGameInfo;
 import lombok.AllArgsConstructor;
@@ -16,7 +17,7 @@ public class MemberProfileResponse {
 
     private String nickname;    // 게임 닉네임
     private ProfileImg profileImg;
-    private Long level; // 유저 레벨
+    private Level level; // 유저 레벨
     private Long exp;   // 유저 경험치
     private GameRole inGameRole;  // 게임 내 직업
     private Long memberId;

--- a/src/main/java/com/springles/domain/entity/GameRecord.java
+++ b/src/main/java/com/springles/domain/entity/GameRecord.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -40,8 +41,11 @@ public class GameRecord {
     private boolean open; // 공개방 / 비밀방
 
     @Column(nullable = false)
-    private boolean winner; // 이긴팀
+    private boolean winner; // 이긴팀 (true: 마피아, false: 시민)?
 
     @Column(nullable = false)
     private LocalDateTime duration; // 게임 진행 시간
+
+    // entity 맵핑 필요
+    private Long memberId;
 }

--- a/src/main/java/com/springles/domain/entity/MemberGameInfo.java
+++ b/src/main/java/com/springles/domain/entity/MemberGameInfo.java
@@ -28,6 +28,7 @@ public class MemberGameInfo {
     private ProfileImg profileImg;  // 프로필 이미지
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private Level level; // 유저 레벨
 
     @Column(nullable = false)

--- a/src/main/java/com/springles/domain/entity/MemberGameInfo.java
+++ b/src/main/java/com/springles/domain/entity/MemberGameInfo.java
@@ -1,6 +1,7 @@
 package com.springles.domain.entity;
 
 import com.springles.domain.constants.GameRole;
+import com.springles.domain.constants.Level;
 import com.springles.domain.constants.ProfileImg;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -27,7 +28,7 @@ public class MemberGameInfo {
     private ProfileImg profileImg;  // 프로필 이미지
 
     @Column(nullable = false)
-    private Long level; // 유저 레벨
+    private Level level; // 유저 레벨
 
     @Column(nullable = false)
     private Long exp;   // 유저 경험치
@@ -35,7 +36,7 @@ public class MemberGameInfo {
     @Enumerated(EnumType.STRING)
     private GameRole inGameRole;  // 게임 내 직업
 
-    // entity 연결 필요
+    // entity 맵핑 필요
     @Column(nullable = false)
     private Long memberId;   // memberId
 }

--- a/src/main/java/com/springles/exception/constants/ErrorCode.java
+++ b/src/main/java/com/springles/exception/constants/ErrorCode.java
@@ -60,7 +60,10 @@ public enum ErrorCode {
     DELETED_MEMBER(HttpStatus.BAD_REQUEST, "탈퇴한 회원입니다."),
     FAIL_SEND_MEMBER_ID(HttpStatus.INTERNAL_SERVER_ERROR,"아이디 메일 전송을 실패하였습니다."),
     FAIL_SEND_MEMBER_PW(HttpStatus.INTERNAL_SERVER_ERROR,"비밀번호 메일 전송을 실패하였습니다."),
-    NOT_FOUND_INPUT_VALUE_MEMBER(HttpStatus.NOT_FOUND, "입력한 정보와 일치하는 회원정보가 없습니다.");
+    NOT_FOUND_INPUT_VALUE_MEMBER(HttpStatus.NOT_FOUND, "입력한 정보와 일치하는 회원정보가 없습니다."),
+    NOT_FOUND_GAME_INFO(HttpStatus.NOT_FOUND, "등록된 게임정보(프로필)이 없습니다."),
+    NOT_FOUND_GAME_RECORD(HttpStatus.NOT_FOUND, "참여한 게임기록이 없습니다."),
+    NO_IN_GAME_ROLE(HttpStatus.BAD_REQUEST, "부여된 GameRole이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/springles/exception/constants/ErrorCode.java
+++ b/src/main/java/com/springles/exception/constants/ErrorCode.java
@@ -62,7 +62,6 @@ public enum ErrorCode {
     FAIL_SEND_MEMBER_PW(HttpStatus.INTERNAL_SERVER_ERROR,"비밀번호 메일 전송을 실패하였습니다."),
     NOT_FOUND_INPUT_VALUE_MEMBER(HttpStatus.NOT_FOUND, "입력한 정보와 일치하는 회원정보가 없습니다."),
     NOT_FOUND_GAME_INFO(HttpStatus.NOT_FOUND, "등록된 게임정보(프로필)이 없습니다."),
-    NOT_FOUND_GAME_RECORD(HttpStatus.NOT_FOUND, "참여한 게임기록이 없습니다."),
     NO_IN_GAME_ROLE(HttpStatus.BAD_REQUEST, "부여된 GameRole이 없습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/springles/repository/GameRecordJpaRepository.java
+++ b/src/main/java/com/springles/repository/GameRecordJpaRepository.java
@@ -2,10 +2,14 @@ package com.springles.repository;
 
 import com.springles.domain.entity.GameRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface GameRecordJpaRepository extends JpaRepository<GameRecord, Long> {
-    List<GameRecord> findTOP1ByMemberIdOrderByIdDesc(Long memberId);
+
+    @Query("SELECT gr FROM GameRecord gr WHERE gr.memberId = :memberId ORDER BY gr.id DESC LIMIT 1")
+    GameRecord findTOP1ByMemberIdOrderByIdDesc(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/springles/repository/GameRecordJpaRepository.java
+++ b/src/main/java/com/springles/repository/GameRecordJpaRepository.java
@@ -1,0 +1,11 @@
+package com.springles.repository;
+
+import com.springles.domain.entity.GameRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GameRecordJpaRepository extends JpaRepository<GameRecord, Long> {
+    List<GameRecord> findTOP1ByMemberIdOrderByIdDesc(Long memberId);
+}

--- a/src/main/java/com/springles/repository/support/MemberGameInfoJpaRepository.java
+++ b/src/main/java/com/springles/repository/support/MemberGameInfoJpaRepository.java
@@ -2,9 +2,23 @@ package com.springles.repository.support;
 
 import com.springles.domain.entity.MemberGameInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberGameInfoJpaRepository extends JpaRepository<MemberGameInfo, Long> {
     Optional<MemberGameInfo> findByMemberId(Long memberId);
+
+    @Query(value =
+            "SELECT ranking " +
+                    "FROM (" +
+                    "SELECT *, (DENSE_RANK() OVER(ORDER BY exp DESC))" +
+                    "AS ranking " +
+                    "FROM member_game_info" +
+                    ") " +
+                    "AS list " +
+                    "WHERE member_id = ?"
+            , nativeQuery = true)
+    Long findByMemberRank(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/springles/service/MemberService.java
+++ b/src/main/java/com/springles/service/MemberService.java
@@ -37,4 +37,6 @@ public interface MemberService {
     MemberProfileResponse levelUp(Long memberId);
 
     Level nextLevel(Level rawLevel);
+
+    Long rank(Long memberId);
 }

--- a/src/main/java/com/springles/service/MemberService.java
+++ b/src/main/java/com/springles/service/MemberService.java
@@ -34,7 +34,7 @@ public interface MemberService {
 
     MemberProfileRead readProfile(String authHeader);
 
-    MemberProfileResponse levelUp(String authHeader);
+    MemberProfileResponse levelUp(Long memberId);
 
     Level nextLevel(Level rawLevel);
 }

--- a/src/main/java/com/springles/service/MemberService.java
+++ b/src/main/java/com/springles/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.springles.service;
 
+import com.springles.domain.constants.Level;
 import com.springles.domain.dto.member.*;
 
 import java.io.IOException;
@@ -34,4 +35,6 @@ public interface MemberService {
     MemberProfileRead readProfile(String authHeader);
 
     MemberProfileResponse levelUp(String authHeader);
+
+    Level nextLevel(Level rawLevel);
 }

--- a/src/main/java/com/springles/service/MemberService.java
+++ b/src/main/java/com/springles/service/MemberService.java
@@ -32,4 +32,6 @@ public interface MemberService {
     MemberProfileResponse updateProfile(MemberProfileUpdateRequest memberDto, String authHeader);
 
     MemberProfileRead readProfile(String authHeader);
+
+    MemberProfileResponse levelUp(String authHeader);
 }

--- a/src/main/java/com/springles/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/springles/service/impl/MemberServiceImpl.java
@@ -515,7 +515,7 @@ public class MemberServiceImpl implements MemberService {
                 ? 200 : 100);
 
         // 레벨업이 가능할 경우
-        if (exp >= goalExp) {
+        if(!(level.equals(Level.BOSS) || level.equals(Level.NONE)) && (exp >= goalExp)) {
             level = nextLevel(level);
         }
 
@@ -547,8 +547,7 @@ public class MemberServiceImpl implements MemberService {
         } else if (rawLevel.equals(Level.UNDERBOSS)) {
             return Level.BOSS;
         } else
-            // 현재 레벨이 BOSS일 경우 null 반환
-            return null;
+            return Level.NONE;
     }
 
     @Override

--- a/src/main/java/com/springles/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/springles/service/impl/MemberServiceImpl.java
@@ -1,16 +1,15 @@
 package com.springles.service.impl;
 
-
+import com.springles.domain.constants.GameRole;
 import com.springles.domain.dto.chatroom.ChatRoomResponseDto;
+import com.springles.domain.constants.Level;
 import com.springles.domain.dto.member.*;
-import com.springles.domain.entity.BlackListToken;
-import com.springles.domain.entity.Member;
-import com.springles.domain.entity.MemberGameInfo;
-import com.springles.domain.entity.RefreshToken;
+import com.springles.domain.entity.*;
 import com.springles.exception.CustomException;
 import com.springles.exception.constants.ErrorCode;
 import com.springles.jwt.JwtTokenUtils;
 import com.springles.repository.BlackListTokenRedisRepository;
+import com.springles.repository.GameRecordJpaRepository;
 import com.springles.repository.MemberJpaRepository;
 import com.springles.repository.RefreshTokenRedisRepository;
 import com.springles.repository.support.MemberGameInfoJpaRepository;
@@ -43,13 +42,14 @@ public class MemberServiceImpl implements MemberService {
     private final BlackListTokenRedisRepository blackListTokenRedisRepository;
     private final RefreshTokenRedisRepository refreshTokenRedisRepository;
     private final MemberGameInfoJpaRepository memberGameInfoJpaRepository;
+    private final GameRecordJpaRepository gameRecordJpaRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenUtils jwtTokenUtils;
     private final JavaMailSender javaMailSender;
 
     // 사용자 정보 가져오기
     @Override
-    public MemberInfoResponse getUserInfo(String authHeader){
+    public MemberInfoResponse getUserInfo(String authHeader) {
 
         String memberName = jwtTokenUtils.parseClaims(authHeader).getSubject();   // AccessToken으로 닉네임 받아오기
 
@@ -160,7 +160,7 @@ public class MemberServiceImpl implements MemberService {
 
         // 기존에 생성된 refreshToken이 있을 경우 삭제
         Optional<RefreshToken> optionalRefreshToken = refreshTokenRedisRepository.findByMemberName(memberDto.getMemberName());
-        if(optionalRefreshToken.isPresent()) {
+        if (optionalRefreshToken.isPresent()) {
             refreshTokenRedisRepository.deleteById(optionalRefreshToken.get().getId());
         }
 
@@ -206,7 +206,7 @@ public class MemberServiceImpl implements MemberService {
         }
         // refreshToken 삭제
         Optional<RefreshToken> optionalRefreshToken = refreshTokenRedisRepository.findByMemberName(memberName);
-        if(optionalRefreshToken.isEmpty()) {
+        if (optionalRefreshToken.isEmpty()) {
             throw new CustomException(ErrorCode.NO_JWT_TOKEN);
         }
         refreshTokenRedisRepository.deleteById(optionalRefreshToken.get().getId());
@@ -215,7 +215,7 @@ public class MemberServiceImpl implements MemberService {
         BlackListToken blackListToken = BlackListToken.builder()
                 .accessToken(authHeader.split(" ")[1])
                 // accessToken의 남은 유효시간만큼만 저장
-                .expiration((rawExpiration.getTime() - Date.from(Instant.now()).getTime())/1000)
+                .expiration((rawExpiration.getTime() - Date.from(Instant.now()).getTime()) / 1000)
                 .build();
         log.info("token Expiration : " + rawExpiration);
 
@@ -227,7 +227,7 @@ public class MemberServiceImpl implements MemberService {
     public String vertificationId(MemberVertifIdRequest memberDto) {
 
         List<Member> memberList = memberRepository.findAllByEmail(memberDto.getEmail());
-        if(memberList.isEmpty()) {
+        if (memberList.isEmpty()) {
             throw new CustomException(ErrorCode.NOT_FOUND_INPUT_VALUE_MEMBER);
         }
 
@@ -293,7 +293,7 @@ public class MemberServiceImpl implements MemberService {
         String tempPassword = randomPassword();
 
         Optional<Member> optionalMember = memberRepository.findByMemberNameAndEmail(memberName, email);
-        if(optionalMember.isEmpty()) {
+        if (optionalMember.isEmpty()) {
             throw new CustomException(ErrorCode.NOT_FOUND_INPUT_VALUE_MEMBER);
         }
 
@@ -362,7 +362,7 @@ public class MemberServiceImpl implements MemberService {
                 '!', '@', '#', '$', '%', '^', '&', '*'
         };
 
-        for(int i = 0; i < 8; i++) {
+        for (int i = 0; i < 8; i++) {
             int index = (int) (Math.random() * charSet.length);
             tempPassword += charSet[index];
         }
@@ -386,7 +386,7 @@ public class MemberServiceImpl implements MemberService {
             throw new CustomException(ErrorCode.DELETED_MEMBER);
         }
 
-        Optional<MemberGameInfo> optionalMemberGameInfo =  memberGameInfoJpaRepository.findByMemberId(optionalMember.get().getId());
+        Optional<MemberGameInfo> optionalMemberGameInfo = memberGameInfoJpaRepository.findByMemberId(optionalMember.get().getId());
 
         // 이미 프로필이 설정되어 있는지 체크
         if (optionalMemberGameInfo.isPresent()) {
@@ -414,7 +414,7 @@ public class MemberServiceImpl implements MemberService {
             throw new CustomException(ErrorCode.DELETED_MEMBER);
         }
 
-        Optional<MemberGameInfo> optionalMemberGameInfo =  memberGameInfoJpaRepository.findByMemberId(optionalMember.get().getId());
+        Optional<MemberGameInfo> optionalMemberGameInfo = memberGameInfoJpaRepository.findByMemberId(optionalMember.get().getId());
 
         // 이미 프로필이 설정되어 있는지 체크
         if (optionalMemberGameInfo.isEmpty()) {
@@ -444,7 +444,7 @@ public class MemberServiceImpl implements MemberService {
             throw new CustomException(ErrorCode.DELETED_MEMBER);
         }
 
-        Optional<MemberGameInfo> optionalMemberGameInfo =  memberGameInfoJpaRepository.findByMemberId(optionalMember.get().getId());
+        Optional<MemberGameInfo> optionalMemberGameInfo = memberGameInfoJpaRepository.findByMemberId(optionalMember.get().getId());
 
         // 이미 프로필이 설정되어 있는지 체크
         if (optionalMemberGameInfo.isEmpty()) {
@@ -454,10 +454,108 @@ public class MemberServiceImpl implements MemberService {
         return MemberProfileRead.builder()
                 .nickname(optionalMemberGameInfo.get().getNickname())
                 .profileImg(optionalMemberGameInfo.get().getProfileImg())
-                .level(optionalMemberGameInfo.get().getLevel())
+                .level(optionalMemberGameInfo.get().getLevel().getName())
                 .exp(optionalMemberGameInfo.get().getExp())
-                .nextLevel(optionalMemberGameInfo.get().getLevel() + 1)
+                // 최종레벨일 경우, nextLevel 비노출 필요
+                .nextLevel(nextLevel(optionalMemberGameInfo.get().getLevel()).getName())
                 .build();
+    }
+
+    @Override
+    public MemberProfileResponse levelUp(String authHeader) {
+        String memberName = jwtTokenUtils.parseClaims(authHeader.split(" ")[1]).getSubject();
+
+        // 헤더의 회원정보가 존재하는 회원정보인지 체크
+        Optional<Member> optionalMember = memberRepository.findByMemberName(memberName);
+        if (optionalMember.isEmpty()) {
+            throw new CustomException(ErrorCode.NOT_FOUND_MEMBER);
+        }
+
+        // 탈퇴한 회원인지 체크
+        if (optionalMember.get().getIsDeleted()) {
+            throw new CustomException(ErrorCode.DELETED_MEMBER);
+        }
+
+        // 해당 회원의 게임정보 호출
+        Optional<MemberGameInfo> optionalMemberGameInfo = memberGameInfoJpaRepository.findByMemberId(optionalMember.get().getId());
+        if (optionalMemberGameInfo.isEmpty()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        // 해당 회원의 가장 최근 게임기록 호출
+        List<GameRecord> gameRecordList = gameRecordJpaRepository.findTOP1ByMemberIdOrderByIdDesc(optionalMember.get().getId());
+        if (gameRecordList.isEmpty()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        // 현재 경험치
+        Long exp = optionalMemberGameInfo.get().getExp();
+
+        // 현재 레벨
+        Level level = optionalMemberGameInfo.get().getLevel();
+
+        // 레벨업까지 목표 경험치
+        Long goalExp = level.getGoalExp();
+
+        // 게임 속 내 역할
+        String inGameRole = optionalMemberGameInfo.get().getInGameRole().getVal();
+
+        // 이긴 팀(true: 마피아, false: 시민)
+        boolean isWinner = true;
+        for(GameRecord gameRecord : gameRecordList) {
+            isWinner = gameRecord.isWinner();
+        }
+
+        // 게임 속 내 역할이 없을 경우
+        if (inGameRole.equals("NONE")) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        // 내 역할의 팀이 이겼을 경우
+        if (isWinner && inGameRole.equals("MAFIA")
+                || !isWinner && !inGameRole.equals("MAFIA")) {
+            exp += 200;
+        }
+        // 내 역할의 팀이 졌을 경우
+        else if (isWinner && !(inGameRole.equals("MAFIA"))
+                || !isWinner && inGameRole.equals("MAFIA")) {
+            exp += 100;
+        }
+
+        // 레벨업이 가능할 경우
+        if (exp >= goalExp) {
+            level = nextLevel(level);
+        }
+
+        // 멤버 게임정보 업데이트
+        MemberGameInfo updateLevelAndExp = MemberGameInfo.builder()
+                .id(optionalMemberGameInfo.get().getId())
+                .memberId(optionalMemberGameInfo.get().getMemberId())
+                .nickname(optionalMemberGameInfo.get().getNickname())
+                .profileImg(optionalMemberGameInfo.get().getProfileImg())
+                .level(level)
+                .exp(exp)
+                .inGameRole(optionalMemberGameInfo.get().getInGameRole())
+                .build();
+
+        memberGameInfoJpaRepository.save(updateLevelAndExp);
+        return MemberProfileResponse.of(updateLevelAndExp, optionalMember.get().getId());
+    }
+
+    public Level nextLevel(Level rawLevel) {
+        if (rawLevel.equals(Level.BEGINNER)) {
+            return Level.ASSOCIATE;
+        } else if (rawLevel.equals(Level.ASSOCIATE)) {
+            return Level.SOLDIER;
+        } else if (rawLevel.equals(Level.SOLDIER)) {
+            return Level.CAPTAIN;
+        } else if (rawLevel.equals(Level.CAPTAIN)) {
+            return Level.UNDERBOSS;
+        } else if (rawLevel.equals(Level.UNDERBOSS)) {
+            return Level.BOSS;
+        } else
+            // 현재 레벨이 BOSS일 경우 null 반환
+            return null;
     }
 
     @Override

--- a/src/main/java/com/springles/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/springles/service/impl/MemberServiceImpl.java
@@ -459,6 +459,7 @@ public class MemberServiceImpl implements MemberService {
                 .exp(optionalMemberGameInfo.get().getExp())
                 // 최종레벨일 경우, nextLevel 비노출 필요
                 .nextLevel(nextLevel(optionalMemberGameInfo.get().getLevel()).getName())
+                .rank(rank(optionalMember.get().getId()))
                 .build();
     }
 
@@ -520,6 +521,11 @@ public class MemberServiceImpl implements MemberService {
 
         memberGameInfoJpaRepository.save(updateLevelAndExp);
         return MemberProfileResponse.of(updateLevelAndExp, memberId);
+    }
+
+    @Override
+    public Long rank(Long memberId) {
+        return memberGameInfoJpaRepository.findByMemberRank(memberId);
     }
 
     @Override

--- a/src/main/java/com/springles/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/springles/service/impl/MemberServiceImpl.java
@@ -534,6 +534,7 @@ public class MemberServiceImpl implements MemberService {
         return MemberProfileResponse.of(updateLevelAndExp, optionalMember.get().getId());
     }
 
+    @Override
     public Level nextLevel(Level rawLevel) {
         if (rawLevel.equals(Level.BEGINNER)) {
             return Level.ASSOCIATE;

--- a/src/main/java/com/springles/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/springles/service/impl/MemberServiceImpl.java
@@ -479,13 +479,13 @@ public class MemberServiceImpl implements MemberService {
         // 해당 회원의 게임정보 호출
         Optional<MemberGameInfo> optionalMemberGameInfo = memberGameInfoJpaRepository.findByMemberId(optionalMember.get().getId());
         if (optionalMemberGameInfo.isEmpty()) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+            throw new CustomException(ErrorCode.NOT_FOUND_GAME_INFO);
         }
 
         // 해당 회원의 가장 최근 게임기록 호출
         List<GameRecord> gameRecordList = gameRecordJpaRepository.findTOP1ByMemberIdOrderByIdDesc(optionalMember.get().getId());
         if (gameRecordList.isEmpty()) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+            throw new CustomException(ErrorCode.NOT_FOUND_GAME_RECORD);
         }
 
         // 현재 경험치
@@ -508,7 +508,7 @@ public class MemberServiceImpl implements MemberService {
 
         // 게임 속 내 역할이 없을 경우
         if (inGameRole.equals("NONE")) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+            throw new CustomException(ErrorCode.NO_IN_GAME_ROLE);
         }
 
         // 내 역할의 팀이 이겼을 경우

--- a/src/main/java/com/springles/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/springles/service/impl/MemberServiceImpl.java
@@ -463,28 +463,16 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public MemberProfileResponse levelUp(String authHeader) {
-        String memberName = jwtTokenUtils.parseClaims(authHeader.split(" ")[1]).getSubject();
-
-        // 헤더의 회원정보가 존재하는 회원정보인지 체크
-        Optional<Member> optionalMember = memberRepository.findByMemberName(memberName);
-        if (optionalMember.isEmpty()) {
-            throw new CustomException(ErrorCode.NOT_FOUND_MEMBER);
-        }
-
-        // 탈퇴한 회원인지 체크
-        if (optionalMember.get().getIsDeleted()) {
-            throw new CustomException(ErrorCode.DELETED_MEMBER);
-        }
+    public MemberProfileResponse levelUp(Long memberId) {
 
         // 해당 회원의 게임정보 호출
-        Optional<MemberGameInfo> optionalMemberGameInfo = memberGameInfoJpaRepository.findByMemberId(optionalMember.get().getId());
+        Optional<MemberGameInfo> optionalMemberGameInfo = memberGameInfoJpaRepository.findByMemberId(memberId);
         if (optionalMemberGameInfo.isEmpty()) {
             throw new CustomException(ErrorCode.NOT_FOUND_GAME_INFO);
         }
 
         // 가장 최근 게임기록
-        GameRecord gameRecord = gameRecordJpaRepository.findTOP1ByMemberIdOrderByIdDesc(optionalMember.get().getId());
+        GameRecord gameRecord = gameRecordJpaRepository.findTOP1ByMemberIdOrderByIdDesc(memberId);
 
         // 현재 레벨
         Level level = optionalMemberGameInfo.get().getLevel();
@@ -531,7 +519,7 @@ public class MemberServiceImpl implements MemberService {
                 .build();
 
         memberGameInfoJpaRepository.save(updateLevelAndExp);
-        return MemberProfileResponse.of(updateLevelAndExp, optionalMember.get().getId());
+        return MemberProfileResponse.of(updateLevelAndExp, memberId);
     }
 
     @Override


### PR DESCRIPTION
## 🌿 PR타입
- [v] 기능 추가
- [v ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
### 📑 개요
- 레벨업 기능 구현
- 레벨 타입을 Long -> enum으로 변경

###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
65bd71c [feat] 레벨업 기능 구현, 레벨 타입 Long -> enum으로 변경(영향도 있는 api 수정)
 ㄴ API: PATCH / member/levelup
45617c6 [refactor] 에러코드 수정
61f3e4c  [fix] profile 설정 시 inGameRole 기본값 추가
997c1d8 [refactor] Level enum에 @Enumerated 추가(String 타입으로 db 저장)
1976d2e [fix] 경험치 부여 오류 수정
7b6db54 [refactor] nextLevel 인터페이스 구현
d69bfb2 [fix] 현재 Boss레벨일 경우에 대한 조건(로직) 재정의
f78e046 [refactor] levelup 메소드 매개변수를 authHeader -> memberId로 변경
8647606 랭킹 조회 기능 구현

[레벨 정책]
- 게임에서 이겼을 경우 +200exp, 졌을 경우 +100exp
- 기본레벨: BEGINNER

- 경험치에 따른 레벨업
*경험치 200exp 도달: ASSOCIATE
*경험치 1000exp 도달: SOLDIER
*경험치 3000exp 도달: CAPTAIN
*경험치 6000exp 도달: UNDER BOSS
*경험치 10000exp 도달: BOSS

[랭킹 기준]
누적경험치가 높은 순

## 📷 스크린샷

## 👀 기타
이번 pr은 레벨업 기능구현과 프로필쪽 api수정이 섞여버린 것 같습니다..
다음 번 pr부터는 잘 구분하도록 하겠습니다!!