### PR TITLE
:recycle: refactor: <Exception 메시지 통일>

### DIFF
--- a/src/main/java/com/springles/controller/api/ChatRoomController.java
+++ b/src/main/java/com/springles/controller/api/ChatRoomController.java
@@ -21,19 +21,19 @@ public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
 
-//    // 채팅방 생성
-//    @Operation(summary = "채팅방 생성", description = "채팅방 생성")
-//    @PostMapping(value = "/chatrooms", produces = "application/json;charset=UTF-8")
-//    public ResponseEntity<ResResult> createChatRoom(@Valid @RequestBody ChatRoomReqDTO chatRoomReqDTO){
-//        // 응답 메시지 return
-//        ResponseCode responseCode = ResponseCode.CHATROOM_CREATE;
-//        return new ResponseEntity<>(ResResult.builder()
-//                .responseCode(responseCode)
-//                .code(responseCode.getCode())
-//                .message(responseCode.getMessage())
-//                .data(chatRoomService.createChatRoom(chatRoomReqDTO))
-//                .build(), HttpStatus.OK);
-//    }
+    // 채팅방 생성
+    @Operation(summary = "채팅방 생성", description = "채팅방 생성")
+    @PostMapping(value = "/chatrooms", produces = "application/json;charset=UTF-8")
+    public ResponseEntity<ResResult> createChatRoom(@Valid @RequestBody ChatRoomReqDTO chatRoomReqDTO){
+        // 응답 메시지 return
+        ResponseCode responseCode = ResponseCode.CHATROOM_CREATE;
+        return new ResponseEntity<>(ResResult.builder()
+                .responseCode(responseCode)
+                .code(responseCode.getCode())
+                .message(responseCode.getMessage())
+                .data(chatRoomService.createChatRoom(chatRoomReqDTO, 1L))
+                .build(), HttpStatus.OK);
+    }
 
     /**
      /chatrooms?title={title}

--- a/src/main/java/com/springles/exception/ErrorResponse.java
+++ b/src/main/java/com/springles/exception/ErrorResponse.java
@@ -1,45 +1,39 @@
 package com.springles.exception;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.springles.exception.constants.ErrorCode;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.http.HttpStatus;
 
 
 /**
  * Global Exception Handler에서 발생한 에러에 대한 응답 처리를 관리
  */
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Data
+@Builder
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponse {
-    private HttpStatus status;           // 에러 상태 코드
-    private String resultMsg;           // 에러 메시지
-    private String reason;              // 에러 이유
 
-    /**
-     * ErrorResponse 생성자
-     *
-     * @param code   ErrorCode
-     * @param reason String
-     */
-    @Builder
-    protected ErrorResponse(final ErrorCode code, final String reason) {
-        this.resultMsg = code.getMessage();
-        this.status = code.getStatus();
-        this.reason = reason;
+    private ErrorCode errorCode;
+    private String code;
+    private String message;
+    private HttpStatus httpStatus;
+
+    public ErrorResponse(ErrorCode errorCode) {
+//        this.code = errorCode.getStatus().toString();
+//        this.errorCode = errorCode;
+        this.httpStatus = errorCode.getStatus();
+        this.message = errorCode.getMessage();
     }
 
-    /**
-     * Global Exception 전송 타입
-     *
-     * @param code   ErrorCode
-     * @param reason String
-     * @return ErrorResponse
-     */
+    @Builder
+    public ErrorResponse(final ErrorCode code, final String message) {
+        this.httpStatus = code.getStatus();
+        this.message = message;
+    }
+
     public static ErrorResponse of(final ErrorCode code, final String reason) {
         return new ErrorResponse(code, reason);
     }
-
 }

--- a/src/main/java/com/springles/exception/constants/ErrorCode.java
+++ b/src/main/java/com/springles/exception/constants/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
     JACKSON_PROCESS_ERROR(HttpStatus.BAD_REQUEST, "com.fasterxml.jackson.core Exception"),
     NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "요청한 리소스가 존재하지 않습니다."),
     NULL_POINT_ERROR(HttpStatus.NOT_FOUND, "Null Point Exception"),
-    NOT_VALID_ERROR(HttpStatus.NOT_FOUND, " @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않습니다."),
+    NOT_VALID_ERROR(HttpStatus.BAD_REQUEST, " @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않습니다."),
     NOT_VALID_HEADER_ERROR(HttpStatus.NOT_FOUND, "Header에 데이터가 존재하지 않습니다. "),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 오류가 발생했습니다."),
     NOT_AUTHORIZED_CONTENT(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
### 📑 개요
###  🧷 변경사항

## 📷 스크린샷
- controller 요청 시, @Valid에 맞지 않는 DTO 또는 ErrorCode에 해당 되는 요청은 exception 처리 합니다.
- ResponseEntity양식을 message, httpStatus로 통일해 client에서 쉽게 보여줄 수 있습니다.
![image](https://github.com/Techit-Springles/Backend/assets/76635279/df5c93f9-11f4-4ee5-b4ac-740a0ee8b174)

## 👀 기타
