### PR TITLE
Feature/#118 chat room game session union

### DIFF
--- a/src/main/java/com/springles/game/GameSessionManager.java
+++ b/src/main/java/com/springles/game/GameSessionManager.java
@@ -10,6 +10,7 @@ import com.springles.domain.entity.Member;
 import com.springles.domain.entity.Player;
 import com.springles.exception.CustomException;
 import com.springles.exception.constants.ErrorCode;
+import com.springles.repository.ChatRoomJpaRepository;
 import com.springles.repository.GameSessionRedisRepository;
 import com.springles.repository.MemberJpaRepository;
 import com.springles.repository.PlayerRedisRepository;
@@ -31,9 +32,11 @@ public class GameSessionManager {
     private final PlayerRedisRepository playerRedisRepository;
     private final RoleManager roleManager;
     private final MemberJpaRepository memberJpaRepository;
+    private final ChatRoomJpaRepository chatRoomJpaRepository;
 
     /* 게임 세션 생성 */
-    public void createGame(ChatRoom chatRoom) {
+    public void createGame(Long roomId) {
+        ChatRoom chatRoom = chatRoomJpaRepository.findByIdCustom(roomId);
         gameSessionRedisRepository.save(GameSession.of(chatRoom));
         Member member = memberJpaRepository.findById(chatRoom.getOwnerId())
             .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/springles/repository/ChatRoomJpaRepository.java
+++ b/src/main/java/com/springles/repository/ChatRoomJpaRepository.java
@@ -1,6 +1,7 @@
 package com.springles.repository;
 
 import com.springles.domain.constants.ChatRoomCode;
+import com.springles.domain.dto.chatroom.ChatRoomResponseDto;
 import com.springles.domain.entity.ChatRoom;
 import com.springles.repository.custom.ChatRoomCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,5 +11,5 @@ import java.util.Optional;
 
 
 public interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, Long>, ChatRoomCustomRepository {
-    Optional<List<ChatRoom>> findAllByCloseFalseAndState(ChatRoomCode chatRoomCode);
+    List<ChatRoomResponseDto> findAllByCloseFalseAndState(ChatRoomCode chatRoomCode);
 }

--- a/src/main/java/com/springles/repository/custom/ChatRoomCustomRepository.java
+++ b/src/main/java/com/springles/repository/custom/ChatRoomCustomRepository.java
@@ -1,13 +1,14 @@
 package com.springles.repository.custom;
 
 import com.springles.domain.constants.ChatRoomCode;
+import com.springles.domain.dto.chatroom.ChatRoomResponseDto;
 import com.springles.domain.entity.ChatRoom;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomCustomRepository {
-    Optional<List<ChatRoom>> findAllByOwnerId(Long ownerId); //방장 이름으로 chatRoom 찾기에서 사용
-    Optional<List<ChatRoom>> findAllByCloseFalseAndState(ChatRoomCode chatRoomCode);
+    List<ChatRoomResponseDto> findAllByOwnerId(Long ownerId); //방장 이름으로 chatRoom 찾기에서 사용
+    List<ChatRoomResponseDto> findAllByCloseFalseAndState(ChatRoomCode chatRoomCode);
 
 }

--- a/src/main/java/com/springles/repository/custom/ChatRoomCustomRepository.java
+++ b/src/main/java/com/springles/repository/custom/ChatRoomCustomRepository.java
@@ -11,4 +11,6 @@ public interface ChatRoomCustomRepository {
     List<ChatRoomResponseDto> findAllByOwnerId(Long ownerId); //방장 이름으로 chatRoom 찾기에서 사용
     List<ChatRoomResponseDto> findAllByCloseFalseAndState(ChatRoomCode chatRoomCode);
 
+    ChatRoom findByIdCustom(Long roomId);
+
 }

--- a/src/main/java/com/springles/repository/custom/MemberCustomRepository.java
+++ b/src/main/java/com/springles/repository/custom/MemberCustomRepository.java
@@ -6,5 +6,5 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MemberCustomRepository {
-    Optional<List<Member>> findAllByMemberNameContainingIgnoreCase(String nickname);
+    List<Member> findAllByMemberNameContainingIgnoreCase(String nickname);
 }

--- a/src/main/java/com/springles/repository/impl/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/springles/repository/impl/ChatRoomRepositoryImpl.java
@@ -1,10 +1,12 @@
 package com.springles.repository.impl;
 
 import com.springles.domain.constants.ChatRoomCode;
+import com.springles.domain.dto.chatroom.ChatRoomResponseDto;
 import com.springles.domain.entity.ChatRoom;
 import com.springles.repository.custom.ChatRoomCustomRepository;
 import com.springles.repository.support.Querydsl4RepositorySupport;
 import jakarta.transaction.Transactional;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
@@ -16,32 +18,33 @@ import static com.springles.domain.entity.QChatRoom.chatRoom;
 @Repository
 @Transactional
 @Slf4j
-public class ChatRoomRepositoryImpl extends Querydsl4RepositorySupport implements ChatRoomCustomRepository {
+public class ChatRoomRepositoryImpl extends Querydsl4RepositorySupport implements
+    ChatRoomCustomRepository {
 
     public ChatRoomRepositoryImpl() {
         super(ChatRoom.class);
     }
 
     @Override
-    public Optional<List<ChatRoom>> findAllByOwnerId(Long ownerId) {
-        List<ChatRoom> chatRoomList = selectFrom(chatRoom)
-                .where(chatRoom.ownerId.eq(ownerId))
-                .fetch();
-        return Optional.of(chatRoomList);
+    public List<ChatRoomResponseDto> findAllByOwnerId(Long ownerId) {
+        return selectFrom(chatRoom)
+            .where(chatRoom.ownerId.eq(ownerId))
+            .fetch()
+            .stream().map(ChatRoomResponseDto::of).collect(Collectors.toList());
 
     }
 
     @Override
-    public Optional<List<ChatRoom>> findAllByCloseFalseAndState(ChatRoomCode chatRoomCode) {
-        List<ChatRoom> chatRoomList = selectFrom(chatRoom)
-                .where(
-                        chatRoom.close.isFalse(),
-                        chatRoom.state.eq(chatRoomCode.WAITING)
-                )
-                .orderBy(chatRoom.capacity.subtract(chatRoom.head).asc())
-                .fetch();
-
-        return Optional.of(chatRoomList);
+    public List<ChatRoomResponseDto> findAllByCloseFalseAndState(ChatRoomCode chatRoomCode) {
+        return selectFrom(chatRoom)
+            .where(
+                chatRoom.close.isFalse(),
+                chatRoom.state.eq(chatRoomCode.WAITING)
+            )
+            .orderBy(chatRoom.capacity.subtract(chatRoom.head).asc())
+            .fetch()
+            .stream().map(ChatRoomResponseDto::of).collect(Collectors.toList());
+        
     }
 
 }

--- a/src/main/java/com/springles/repository/impl/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/springles/repository/impl/ChatRoomRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.springles.repository.impl;
 import com.springles.domain.constants.ChatRoomCode;
 import com.springles.domain.dto.chatroom.ChatRoomResponseDto;
 import com.springles.domain.entity.ChatRoom;
+import com.springles.exception.CustomException;
+import com.springles.exception.constants.ErrorCode;
 import com.springles.repository.custom.ChatRoomCustomRepository;
 import com.springles.repository.support.Querydsl4RepositorySupport;
 import jakarta.transaction.Transactional;
@@ -44,7 +46,15 @@ public class ChatRoomRepositoryImpl extends Querydsl4RepositorySupport implement
             .orderBy(chatRoom.capacity.subtract(chatRoom.head).asc())
             .fetch()
             .stream().map(ChatRoomResponseDto::of).collect(Collectors.toList());
-        
+
+    }
+
+    @Override
+    public ChatRoom findByIdCustom(Long roomId) {
+        return Optional.ofNullable(selectFrom(chatRoom)
+            .where(chatRoom.id.eq(roomId))
+            .fetchOne()
+        ).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROOM));
     }
 
 }

--- a/src/main/java/com/springles/repository/impl/MemberRepositoryImpl.java
+++ b/src/main/java/com/springles/repository/impl/MemberRepositoryImpl.java
@@ -18,12 +18,12 @@ public class MemberRepositoryImpl extends Querydsl4RepositorySupport implements 
     public MemberRepositoryImpl() {
         super(Member.class);
     }
+
     @Override
-    public Optional<List<Member>> findAllByMemberNameContainingIgnoreCase(String nickname) {
-        List<Member> memberList = selectFrom(member)
-                .where(member.memberName.eq(nickname))
-                .fetch();
-        return Optional.ofNullable(memberList);
+    public List<Member> findAllByMemberNameContainingIgnoreCase(String nickname) {
+        return selectFrom(member)
+            .where(member.memberName.eq(nickname))
+            .fetch();
     }
 
     public static Predicate searchMemberNameContains(String nameContains) {
@@ -33,7 +33,7 @@ public class MemberRepositoryImpl extends Querydsl4RepositorySupport implements 
         builder.and(qmember.memberName.eq(nameContains));
 
         if (StringUtils.isNotEmpty(nameContains)) {
-            builder = builder.and(qmember.memberName.containsIgnoreCase(nameContains));
+            builder.and(qmember.memberName.containsIgnoreCase(nameContains));
         }
 
         return builder;

--- a/src/main/java/com/springles/service/ChatRoomService.java
+++ b/src/main/java/com/springles/service/ChatRoomService.java
@@ -4,10 +4,11 @@ import com.springles.domain.dto.chatroom.ChatRoomReqDTO;
 import com.springles.domain.dto.chatroom.ChatRoomResponseDto;
 import com.springles.domain.dto.chatroom.ChatRoomUpdateReqDto;
 
+import com.springles.domain.entity.ChatRoom;
 import java.util.List;
 
 public interface ChatRoomService {
-    ChatRoomResponseDto createChatRoom(ChatRoomReqDTO chatRoomReqDTO, Long id);
+    ChatRoom createChatRoom(ChatRoomReqDTO chatRoomReqDTO, Long id);
     ChatRoomResponseDto updateChatRoom(ChatRoomUpdateReqDto chatRoomUpdateReqDto, Long chatroomId);
     void deleteChatRoom(Long memberId, Long chatRoomId);
 

--- a/src/main/java/com/springles/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/springles/service/impl/ChatRoomServiceImpl.java
@@ -10,6 +10,8 @@ import com.springles.domain.entity.ChatRoom;
 import com.springles.domain.entity.Member;
 import com.springles.exception.CustomException;
 import com.springles.exception.constants.ErrorCode;
+import com.springles.game.GameSessionManager;
+import com.springles.game.MessageManager;
 import com.springles.repository.ChatRoomJpaRepository;
 import com.springles.repository.MemberJpaRepository;
 import com.springles.service.ChatRoomService;
@@ -35,17 +37,25 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
     private final ChatRoomJpaRepository chatRoomJpaRepository;
     private final MemberJpaRepository memberJpaRepository;
+    private GameSessionManager gameSessionManager;
+    private MessageManager messageManager;
 
-   // 채팅방 생성
+    // 채팅방 생성
     @Transactional
     @Override
     public ChatRoomResponseDto createChatRoom(ChatRoomReqDTO chatRoomReqDTO, Long id) {
         // request 자체가 빈 경우
-        if (chatRoomReqDTO == null) throw new CustomException(ErrorCode.REQUEST_EMPTY);
+        if (chatRoomReqDTO == null) {
+            throw new CustomException(ErrorCode.REQUEST_EMPTY);
+        }
         // 비밀방 선택 - 비밀번호 입력하지 않은 경우 오류 발생
-        if (chatRoomReqDTO.getClose() && chatRoomReqDTO.getPassword() == null) throw new CustomException(ErrorCode.PASSWORD_EMPTY);
+        if (chatRoomReqDTO.getClose() && chatRoomReqDTO.getPassword() == null) {
+            throw new CustomException(ErrorCode.PASSWORD_EMPTY);
+        }
         // 공개방 선택 - 비밀번호 입력한 경우라면
-        if (!chatRoomReqDTO.getClose() && chatRoomReqDTO.getPassword() != null) throw new CustomException(ErrorCode.OPEN_PASSWORD);
+        if (!chatRoomReqDTO.getClose() && chatRoomReqDTO.getPassword() != null) {
+            throw new CustomException(ErrorCode.OPEN_PASSWORD);
+        }
 
         ChatRoom chatRoom = chatRoomJpaRepository.save(createToEntity(chatRoomReqDTO, id));
 
@@ -58,14 +68,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
      */
     @Override
     public List<ChatRoomResponseDto> findAllByCloseFalseAndState() {
-
-        List<ChatRoom> allByCloseFalseAndState = chatRoomJpaRepository.findAllByCloseFalseAndState(ChatRoomCode.WAITING)
-                .orElseThrow( () -> new CustomException(ErrorCode.NOT_FOUND_ROOM));
-        return allByCloseFalseAndState.stream().map(ChatRoomResponseDto::of).toList();
-
+        return chatRoomJpaRepository.findAllByCloseFalseAndState(ChatRoomCode.WAITING);
     }
-
-
 
 
     /**
@@ -80,30 +84,32 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
 
     @Override
-    public  ChatRoomResponseDto chatRoomCondition(Long roomId){
+    public ChatRoomResponseDto chatRoomCondition(Long roomId) {
 
         ChatRoomResponseDto chatRoomResponseDto = findChatRoomByChatRoomId(roomId);
         // 입장 시도 시 정원이 다 찼을 때
-        if(chatRoomResponseDto.getHead() >= chatRoomResponseDto.getCapacity()) throw new CustomException(ErrorCode.GAME_HEAD_FULL);
+        if (chatRoomResponseDto.getHead() >= chatRoomResponseDto.getCapacity()) {
+            throw new CustomException(ErrorCode.GAME_HEAD_FULL);
+        }
         // 비밀 방 일 때
-        if(chatRoomResponseDto.getClose()) throw new CustomException(ErrorCode.CLOSE_ROOM_ERROR);
+        if (chatRoomResponseDto.getClose()) {
+            throw new CustomException(ErrorCode.CLOSE_ROOM_ERROR);
+        }
         // 이미 진행 중 일 때
-        if(chatRoomResponseDto.getState().getValue().equals("PLAYING")) throw new CustomException(ErrorCode.PLAYER_STILL_INGAME);
+        if (chatRoomResponseDto.getState().getValue().equals("PLAYING")) {
+            throw new CustomException(ErrorCode.PLAYER_STILL_INGAME);
+        }
 
         return chatRoomResponseDto;
     }
 
     /**
      * 빠른 입장
-     * 
      */
     @Override
     public ChatRoomResponseDto quickEnter() {
-        List<ChatRoomResponseDto> chatRoomResponseDtoList = chatRoomJpaRepository.findAllByCloseFalseAndState(ChatRoomCode.WAITING) // 오픈된 방이고 , 대기중인 리스트
-                .get()
-                .stream()
-                .sorted(Comparator.comparingLong(o -> (o.getCapacity() - o.getHead())))
-                .map(ChatRoomResponseDto::of).collect(Collectors.toList());
+        List<ChatRoomResponseDto> chatRoomResponseDtoList = chatRoomJpaRepository.findAllByCloseFalseAndState(
+            ChatRoomCode.WAITING); // 오픈된 방이고 , 대기중인 리스트
         try {
             return chatRoomResponseDtoList.get(0);// 정원수 - 입장 인원 수 중 가장 상단에 있는 방
         } catch (IndexOutOfBoundsException e) {
@@ -119,12 +125,12 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     @Override
     public List<ChatRoomResponseDto> findChatRoomByTitle(String title) {
         List<ChatRoom> chatRooms = chatRoomJpaRepository.findAll().stream()
-                .filter(chatRoom -> chatRoom.getTitle().contains(title))
-                .collect(Collectors.toList());
+            .filter(chatRoom -> chatRoom.getTitle().contains(title))
+            .toList();
 
         return chatRooms.stream()
-                .map(ChatRoomResponseDto::of)
-                .collect(Collectors.toList());
+            .map(ChatRoomResponseDto::of)
+            .collect(Collectors.toList());
 
     }
 
@@ -134,20 +140,14 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     @Override
     public List<ChatRoomResponseDto> findChatRoomByNickname(String nickname) {
         // 닉네임이 포함된 멤버 모두 찾기 (대 소문자 구분하지 않음)
-        List<Member> members = memberJpaRepository.findAllByMemberNameContainingIgnoreCase(nickname)
-                .get().stream()
-                .collect(Collectors.toList());
+        List<Member> members = memberJpaRepository.findAllByMemberNameContainingIgnoreCase(
+            nickname);
 
         List<ChatRoomResponseDto> chatRoomResponseDtoList = new ArrayList<>();
 
         for (Member member : members) {
-            Optional<List<ChatRoom>> optionalChatRoomList = chatRoomJpaRepository.findAllByOwnerId(member.getId());
-            if (optionalChatRoomList.isPresent()) {
-                for (ChatRoom chatRoom : optionalChatRoomList.get()) {
-                    chatRoomResponseDtoList.add(ChatRoomResponseDto.of(chatRoom));
-                }
-            }
-
+            chatRoomResponseDtoList.addAll(chatRoomJpaRepository.findAllByOwnerId(
+                member.getId()));
         }
 
         return chatRoomResponseDtoList;
@@ -159,17 +159,21 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     public ChatRoomResponseDto updateChatRoom(ChatRoomUpdateReqDto dto, Long id) {
         // 기존 채팅방 데이터 받기
         ChatRoom findChatRoom = chatRoomJpaRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROOM));
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROOM));
         // 수정을 요청한 사용자와 방장이 일치하는지 확인
-        if (findChatRoom.getOwnerId() != dto.getMemberId()) throw new CustomException(ErrorCode.USER_NOT_OWNER);
+        if (findChatRoom.getOwnerId() != dto.getMemberId()) {
+            throw new CustomException(ErrorCode.USER_NOT_OWNER);
+        }
         // 데이터 수정
         findChatRoom.modify(updateToEntity(dto, id));
         // 비밀방 선택 - 비밀번호 입력하지 않은 경우라면
-        if (findChatRoom.getClose() && findChatRoom.getPassword() == null)
+        if (findChatRoom.getClose() && findChatRoom.getPassword() == null) {
             throw new CustomException(ErrorCode.PASSWORD_EMPTY);
+        }
         // 공개방 선택 - 비밀번호 입력한 경우라면
-        if (!findChatRoom.getClose() && findChatRoom.getPassword() != null)
+        if (!findChatRoom.getClose() && findChatRoom.getPassword() != null) {
             throw new CustomException(ErrorCode.OPEN_PASSWORD);
+        }
         // 수정한 데이터 반환
         return ChatRoomResponseDto.of(findChatRoom);
     }
@@ -180,9 +184,11 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     public void deleteChatRoom(Long memberId, Long chatRoomId) {
         // 기존 채팅방 데이터 받기
         ChatRoom findChatRoom = chatRoomJpaRepository.findById(chatRoomId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROOM));
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROOM));
         // 삭제를 요청한 사용자와 방장이 일치하는지 확인
-        if (findChatRoom.getOwnerId() != memberId) throw new CustomException(ErrorCode.USER_NOT_OWNER);
+        if (findChatRoom.getOwnerId() != memberId) {
+            throw new CustomException(ErrorCode.USER_NOT_OWNER);
+        }
         // 삭제
         chatRoomJpaRepository.delete(findChatRoom);
     }
@@ -194,7 +200,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
      */
     public ChatRoomResponseDto findChatRoomByChatRoomId(Long id) {
         return ChatRoomResponseDto.of(chatRoomJpaRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROOM)));
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROOM)));
     }
 
     // 타이틀 + 이름으로 검색
@@ -203,7 +209,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         List<ChatRoomResponseDto> list = new ArrayList<>();
 
         // 만약 검색어가 없다면 NO_CONTENT 반환
-        if (searchContent.isEmpty()) throw new CustomException(ErrorCode.NO_CONTENT);
+        if (searchContent.isEmpty()) {
+            throw new CustomException(ErrorCode.NO_CONTENT);
+        }
 
         List<ChatRoomResponseDto> chatRoomByNickname = findChatRoomByNickname(searchContent);
         List<ChatRoomResponseDto> chatRoomByTitle = findChatRoomByTitle(searchContent);
@@ -212,16 +220,18 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         list.addAll(chatRoomByNickname);
 
         // 검색 결과가 비어있다면 NOT_FOUND_ROOM 반환
-        if (list.isEmpty()) throw new CustomException(ErrorCode.NOT_FOUND_ROOM);
+        if (list.isEmpty()) {
+            throw new CustomException(ErrorCode.NOT_FOUND_ROOM);
+        }
 
         return list.stream().distinct().toList();
 
     }
 
     // 채팅방 입장 시 채팅 정보 받아오기
-    public ChatRoomResponseDto enterChatRoom(Long roomId){
+    public ChatRoomResponseDto enterChatRoom(Long roomId) {
         ChatRoom findChatRoom = chatRoomJpaRepository.findById(roomId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROOM));
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROOM));
         return ChatRoomResponseDto.of(findChatRoom);
     }
 }

--- a/src/main/java/com/springles/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/springles/service/impl/ChatRoomServiceImpl.java
@@ -43,7 +43,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     // 채팅방 생성
     @Transactional
     @Override
-    public ChatRoomResponseDto createChatRoom(ChatRoomReqDTO chatRoomReqDTO, Long id) {
+    public ChatRoom createChatRoom(ChatRoomReqDTO chatRoomReqDTO, Long id) {
         // request 자체가 빈 경우
         if (chatRoomReqDTO == null) {
             throw new CustomException(ErrorCode.REQUEST_EMPTY);
@@ -57,10 +57,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
             throw new CustomException(ErrorCode.OPEN_PASSWORD);
         }
 
-        ChatRoom chatRoom = chatRoomJpaRepository.save(createToEntity(chatRoomReqDTO, id));
-
         // 채팅방 생성하기
-        return ChatRoomResponseDto.of(chatRoom);
+        return chatRoomJpaRepository.save(createToEntity(chatRoomReqDTO, id));
     }
 
     /**


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
#118 

### 📑 개요
게임 로직이 실행되는 과정은 다음과 같습니다.
- 프론트에서 채팅방을 생성
- 채팅방 생성 API 호출
- 호출 결과 Success라면 게임시작 URL로 메시지 전송
- MessageController에서 메시지를 받고 게임 로직 실행

###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
567baf7 채팅방을 검색할 떄 불필요하게 Optional 객체가 사용되는 코드를 수정했습니다.
5d68ae72f7b6131c371e014470f8696379102476 GameSessionController에서 따로 관리하던 API를 MessageController로 모두 이동했습니다.

