### PR TITLE
:recycle: refactor: <ui controller 대신 api controller 호출로 수정>

### DIFF
--- a/src/main/java/com/springles/controller/ui/ChatRoomUiController.java
+++ b/src/main/java/com/springles/controller/ui/ChatRoomUiController.java
@@ -36,15 +36,14 @@ public class ChatRoomUiController {
 
     // 채팅방 만들기 페이지 (GET)
     @GetMapping("add")
-    public String writeRoom(Model model, ChatRoomReqDTO requestDto) {
-        model.addAttribute("requestDto", requestDto);
+    public String chatroom() {
         return "home/add";
     }
 
-
     // 채팅방 만들기 (POST)
     @PostMapping("add")
-    public String createRoom(@ModelAttribute("requestDto") @Valid ChatRoomReqDTO requestDto, HttpServletRequest request){
+    public String createRoom(){
+//    public String createRoom(@ModelAttribute("requestDto") @Valid ChatRoomReqDTO requestDto, HttpServletRequest request){
 
         // 쿠키에서 accessToken 가져오기
 //        Cookie[] cookies = request.getCookies();
@@ -53,12 +52,7 @@ public class ChatRoomUiController {
 //        Long id = info.getId();
 //        log.info(String.valueOf(id));
 //        chatRoomService.createChatRoom(requestDto,id);
-
-        String accessToken = (String) request.getAttribute("accessToken");
-        MemberInfoResponse info = memberUiController.info(accessToken);
-        Long id = info.getId();
-        log.info(String.valueOf(id));
-        chatRoomService.createChatRoom(requestDto,id);
+//        chatRoomService.createChatRoom(requestDto,id);
 
         return "redirect:index";
     }

--- a/src/main/java/com/springles/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/springles/service/impl/ChatRoomServiceImpl.java
@@ -43,9 +43,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         // request 자체가 빈 경우
         if (chatRoomReqDTO == null) throw new CustomException(ErrorCode.REQUEST_EMPTY);
         // 비밀방 선택 - 비밀번호 입력하지 않은 경우 오류 발생
-        if (chatRoomReqDTO.getClose() && chatRoomReqDTO.getPassword() == null) throw new CustomException(ErrorCode.PASSWORD_EMPTY);
+        if (chatRoomReqDTO.getClose() && chatRoomReqDTO.getPassword().isEmpty()) throw new CustomException(ErrorCode.PASSWORD_EMPTY);
         // 공개방 선택 - 비밀번호 입력한 경우라면
-        if (!chatRoomReqDTO.getClose() && chatRoomReqDTO.getPassword() != null) throw new CustomException(ErrorCode.OPEN_PASSWORD);
+        if (!chatRoomReqDTO.getClose() && !chatRoomReqDTO.getPassword().isEmpty()) throw new CustomException(ErrorCode.OPEN_PASSWORD);
 
         ChatRoom chatRoom = chatRoomJpaRepository.save(createToEntity(chatRoomReqDTO, id));
 

--- a/src/main/resources/templates/home/add.html
+++ b/src/main/resources/templates/home/add.html
@@ -2,78 +2,84 @@
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layouts/basic}">
-
 <div layout:fragment="content">
     <div class="form-container">
         <div class="form-item">
-
-            <form th:action="@{/v1/add}" th:object="${requestDto}" method="post" >
+            <form id="form">
                 <table class="table">
                     <tbody>
                     <div>
                         <label for="title">방 제목</label>
-                        <input type="text" id="title" th:field="*{title}" class="title form-control" placeholder="이름을 입력하세요">
+                        <input type="text" id="title" class="title form-control" placeholder="이름을 입력하세요">
                     </div>
                     <div>
                         <label for="capacity">인원</label>
-                        <input type="text" id="capacity" th:field="*{capacity}" class="capacity form-control" placeholder="인원을 입력하세요">
+                        <input type="text" id="capacity" class="capacity form-control" placeholder="인원을 입력하세요">
                     </div>
                     <div class="checkbox">
                         <input type="checkbox"
                                id="close"
-                               th:field="*{close}"
-                               class="checkbox">
+                               class="checkbox"
+                               value="false">
                         <label for="close" class="checkbox">비밀방</label>
                     </div>
                     <div>
                         <label for="password">비밀번호</label>
-                        <input type="text" id="password" th:field="*{password}" class="form-control" placeholder="비밀번호를 입력하세요">
+                        <input type="text" id="password" class="form-control" placeholder="비밀번호를 입력하세요">
                     </div>
                     <div>
-                        <button id = "Send_Request" class="submit_btn" type="submit">등록</button>
+                        <button id = "Send_Request" class="submit_btn" type="button">등록</button>
                     </div>
                 </table>
                 <!-- javscript 코드, 비밀번호 input 입력 불가능이 기본 사항입니다. -->
             </form>
         </div>
     </div>
-
     <th:block layout:fragment="script">
         <script th:inline="javascript">
-
-            // ======================== 비밀방 체크박스와 비밀번호 설정 =====================================================
-            $('#password').attr('disabled',true);
-            $('#close').on('click', function(){
-                const closeBtn = document.getElementById('close');
-                if( closeBtn.checked ){
-                    $('#password').removeAttr('disabled')
-                } else {
-                    $('#password').attr('disabled',true).val("");
-                }
-            });
-
-            // ===================== 채팅방 생성 버튼 click ==============================================================
             $(function () {
-            $('.submit_btn').click((e) => {
-                const title = $('#title').val();
-                const capacity = $('#capacity').val();
-                const closeBtn = document.getElementById('close');
-                const password = $('#password').val();
+                // ======================== 비밀방 체크박스와 비밀번호 설정 =====================================================
+                $('#password').attr('disabled',true);
+                $('#close').on('click', function(){
+                    const closeBtn = document.getElementById('close');
+                    if( closeBtn.checked ){
+                        $('#close').attr('value', 'true');
+                        $('#password').removeAttr('disabled')
+                    } else {
+                        $('#close').attr('value', 'false');
+                        $('#password').attr('disabled',true).val("");
+                    }
+                });
 
-                if (title === '') {
-                    alert('방 제목을 입력해주세요');
-                    e.preventDefault();
-                }
-                if (capacity === '') {
-                    alert('인원은 5명에서 10명 사이여야 합니다.');
-                    e.preventDefault();
-                }
-                if (closeBtn.checked && password === '') {
-                    alert('비밀번호를 입력해주세요');
-                    e.preventDefault();
-                }
+                // ========================= 채팅방 생성 버튼 ==================================================================
+                $('.submit_btn').click((e) => {
+                    const title = $('#title').val();
+                    const capacity = $('#capacity').val();
+                    const close = $('#close').val()
+                    const password = $('#password').val();
+
+                    const path = 'http://localhost:8080/v1/chatrooms';
+                    const json = JSON.stringify({
+                        'title': title,
+                        'capacity': capacity,
+                        'close': close,
+                        'password': password
+                    });
+                    $.ajax({
+                        url: path,
+                        type: 'POST',
+                        contentType: 'application/json',
+                        data: json,
+                        success: function(data) {
+                            location.href = 'http://localhost:8080/v1/index'
+                        },
+                        error: function(response) {
+                            alert(JSON.stringify(response.responseJSON.message))
+                        },
+                    });
+                });
+                return false;
             });
-        });
         </script>
     </th:block>
 </div>


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
클라이언트를 react 대신 thymeleaf를 사용하면서 api 구조가 mvc로 변경되어 기존 api controller에서 작성한 exceptionHandler를 활용하지 못하게 되었습니다. 직접 ui controller에서 modelAttribute로 값을 받아오는 경우, exception 메시지를 클라이언트에서 모두 작성해야 하는 번거로움이 있습니다. 

### 📑 개요
###  🧷 변경사항
- ui controller -> api controller로 수정 
ui controller는 화면 렌더링에만 사용하며, error 발생 시, exception message를 클라이언트에서 받을 수 있도록 수정했습니다. 

## 📷 스크린샷
@Valid requestdto의 메시지와 ErrorCode 메시지를 클라이언트에서 alert로 받을 수 있습니다. 
![image](https://github.com/Techit-Springles/Backend/assets/76635279/9addcb93-f794-41ff-86a8-ab7a83ded84d)
![image](https://github.com/Techit-Springles/Backend/assets/76635279/a9e7d4e0-dc8d-4473-84f9-b9dd791d6efd)
![image](https://github.com/Techit-Springles/Backend/assets/76635279/e91b5872-7247-4a05-a5b8-4e6262ee72b2)
![image](https://github.com/Techit-Springles/Backend/assets/76635279/e66a1a58-5133-408d-a3ad-5b18a0a52be3)

## 👀 기타
