### PR TITLE
:sparkles: feat: 프로필정보 db와 연동, 아이디 -> 닉네임으로 변경

### DIFF
--- a/src/main/java/com/springles/service/MemberService.java
+++ b/src/main/java/com/springles/service/MemberService.java
@@ -11,7 +11,10 @@ import java.util.Map;
 public interface MemberService {
 
     // 사용자 정보 API
-    MemberInfoResponse getUserInfo(String authHeader);
+    MemberInfoResponse getUserInfo(String accessToken);
+
+    // 사용자 프로필 정보 호출
+    MemberProfileResponse getUserProfileInfo(String accessToken);
 
     String signUp(MemberCreateRequest memberDto);
 

--- a/src/main/java/com/springles/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/springles/service/impl/MemberServiceImpl.java
@@ -39,12 +39,26 @@ public class MemberServiceImpl implements MemberService {
 
     // 사용자 정보 가져오기
     @Override
-    public MemberInfoResponse getUserInfo(String authHeader) {
+    public MemberInfoResponse getUserInfo(String accessToken) {
 
-        String memberName = jwtTokenUtils.parseClaims(authHeader).getSubject();   // AccessToken으로 닉네임 받아오기
+        String memberName = jwtTokenUtils.parseClaims(accessToken).getSubject();   // AccessToken으로 닉네임 받아오기
 
         return MemberInfoResponse.of(memberRepository.findByMemberName(memberName) // 닉네임으로 info dto 반환
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER)));
+    }
+
+    // 사용자 프로필 정보 가져오기
+    public MemberProfileResponse getUserProfileInfo(String accessToken) {
+        String memberName = jwtTokenUtils.parseClaims(accessToken).getSubject();
+
+        Optional<Member> optionalMember = memberRepository.findByMemberName(memberName);
+        if(optionalMember.isEmpty()) {
+            throw new CustomException(ErrorCode.NOT_FOUND_MEMBER);
+        }
+
+        Optional<MemberGameInfo> optionalMemberGameInfo = memberGameInfoJpaRepository.findByMemberId(optionalMember.get().getId());
+
+        return MemberProfileResponse.of(optionalMemberGameInfo.get(), optionalMember.get().getId());
     }
 
     @Override

--- a/src/main/resources/static/css/basic.css
+++ b/src/main/resources/static/css/basic.css
@@ -64,7 +64,7 @@ body {
 }
 
 .my_bg {
-    background-image: url("../images/profile.png");
+    /*background-image: url("../images/profile.png");*/
     background-size: 100% 100%;
     align-items:center;
     justify-content: center;

--- a/src/main/resources/templates/home/index.html
+++ b/src/main/resources/templates/home/index.html
@@ -11,14 +11,16 @@
                 <!-----------------------사용자 정보 ----------------------------------------------------------->
                 <div class="card profile">
                     <!---------레벨 ---------->
-                    <div class="card-header text-white" style="border-radius: 14px;">BEGINNER (아이콘)</div>
+                    <div class="card-header text-white" style="border-radius: 14px;" th:text="${member.getLevel()}"></div>
                     <div class="card-body2 container row">
                         <!--------- 프로필 사진 -------->
                         <div class="my_div my_bg col m-3 p-0">
+                            <img class="my_bg_img" id="profileImg" th:src="${member.getProfileImg().getFileUrl()}"
+                                 alt="프로필이미지"/>
                         </div>
                         <!--------------------- 닉네임 -------->
                         <div class="nick-name-box col p-3">
-                            <div class="nick-name" th:text="${member.getMemberName()}"></div>
+                            <div class="nick-name" th:text="${member.getNickname()}"></div>
                         </div>
                     </div>
                 </div>
@@ -68,8 +70,8 @@
                 <div class="chat_list_ui" id="chatRoom">
                     <div th:if="${allChatRooms != null}">
                         <div th:id="'room_' + ${i.index}" class="list-group" th:each="room, i: ${allChatRooms}">
-                            <a th:href="@{/chat/{roomId}/{nickName} (roomId=${room.id},nickName=${member.memberName})}"
-                               th:attrappend="roomId=${room.id},nickName=${member.memberName},isClose=${room.getClose()}"
+                            <a th:href="@{/chat/{roomId}/{nickName} (roomId=${room.id},nickName=${member.getNickname()})}"
+                               th:attrappend="roomId=${room.id},nickName=${member.getNickname()},isClose=${room.getClose()}"
                                id="chatroom-url" name="chatroom-url"
                                class="list-group-item list-group-item-action flex-column align-items-start">
                                 <div class="d-flex w-100 justify-content-between">
@@ -102,7 +104,7 @@
                             <div th:id="'passwordInput_' + ${room.id}" class="password-input" style="display: none;">
                                 <input type="text" name="userInput" id="userInput"/>
                                 <button type="button" id="password-submit" name="password-submit" class="submit_btn"
-                                        th:attr="data-roomId=${room.id},data-nickName=${member.memberName},data-isClose=${room.close},data-roomPassword=${room.password}">
+                                        th:attr="data-roomId=${room.id},data-nickName=${member.getNickname()},data-isClose=${room.close},data-roomPassword=${room.password}">
                                     확인
                                 </button>
                             </div>


### PR DESCRIPTION
## 🌿 PR타입
- [v] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
### 📑 개요
- 메인페이지의 프로필 정보를 db와 연동
###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- 메인페이지의 프로필 정보를 MemberGameInfo entity와 연동
- 아이디가 아니라 닉네임이 출력되도록 변경

## 📷 스크린샷
![image](https://github.com/Techit-Springles/Backend/assets/126767770/0c6442c7-5818-4273-b7de-06a49aec1e36)


## 👀 기타
- 검색영역도 아이디가 아니라 닉네임으로 변경하려고 수정을 시도했다가.. 테스트코드 등 얽혀있는 코드가 너무 많은 것 같아 포기했습니다...ㅎㅎ ㅠㅠ
