### PR TITLE
[Feature] 채팅방 입장, 퇴장 메시지 출력 + 참여자 목록 실시간 변동 추가

### DIFF
--- a/src/main/java/com/springles/config/WebSocketStompConfig.java
+++ b/src/main/java/com/springles/config/WebSocketStompConfig.java
@@ -27,7 +27,7 @@ public class WebSocketStompConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
 
-        registry.addEndpoint("/chatting");
+        registry.addEndpoint("/chatting").setAllowedOrigins("*");
     }
 
 
@@ -41,9 +41,9 @@ public class WebSocketStompConfig implements WebSocketMessageBrokerConfigurer {
         registry.enableSimpleBroker("/topic",
                 "/sub/chat",
             "/sub/gameStart",
-            "/sub/player",
             "/sub/joinGame",
-            "/sub/exitGame"
+            "/sub/exitGame",
+            "/sub/gameRole"
             );
 
         // 발신

--- a/src/main/java/com/springles/controller/api/ChatRoomController.java
+++ b/src/main/java/com/springles/controller/api/ChatRoomController.java
@@ -3,6 +3,7 @@ package com.springles.controller.api;
 import com.springles.controller.ui.MemberUiController;
 import com.springles.domain.constants.ResponseCode;
 import com.springles.domain.dto.chatroom.ChatRoomReqDTO;
+import com.springles.domain.dto.chatroom.ChatRoomResponseDto;
 import com.springles.domain.dto.chatroom.ChatRoomUpdateReqDto;
 import com.springles.domain.dto.member.MemberCreateRequest;
 import com.springles.domain.dto.member.MemberInfoResponse;
@@ -109,4 +110,12 @@ public class ChatRoomController {
         chatRoomService.deleteChatRoom(memberId, chatroomid);
         return "redirect:/v1/chatrooms";
     }
+
+    @GetMapping("/chatRooms/{roomId}")
+    public ChatRoomResponseDto findRoomInfo(
+        @PathVariable Long roomId
+    ) {
+        return chatRoomService.findChatRoomByChatRoomId(roomId);
+    }
+
 }

--- a/src/main/java/com/springles/domain/dto/message/RoleExplainMessage.java
+++ b/src/main/java/com/springles/domain/dto/message/RoleExplainMessage.java
@@ -1,0 +1,29 @@
+package com.springles.domain.dto.message;
+
+import com.springles.domain.constants.GameRole;
+import com.springles.domain.constants.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.context.annotation.Bean;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RoleExplainMessage {
+
+    GameRole gameRole;
+    String message;
+    String sender;
+    String time;
+
+    public RoleExplainMessage(GameRole gameRole, String time) {
+        this.gameRole = gameRole;
+        this.message = "당신의 직업은 " + gameRole + "입니다.";
+        this.sender = "admin";
+        this.time = time;
+    }
+
+}

--- a/src/main/java/com/springles/game/GameSessionManager.java
+++ b/src/main/java/com/springles/game/GameSessionManager.java
@@ -37,9 +37,6 @@ public class GameSessionManager {
     public void createGame(Long roomId) {
         ChatRoom chatRoom = chatRoomJpaRepository.findByIdCustom(roomId);
         gameSessionRedisRepository.save(GameSession.of(chatRoom));
-        Member member = memberJpaRepository.findById(chatRoom.getOwnerId())
-            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        addUser(chatRoom.getId(), member.getMemberName());
     }
 
     /* 게임 시작 */

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,69 @@
-insert into member (email,is_deleted,member_name,password,role) values ('dsd2@naver.com',0,'ssssss','$2a$10$jWpTgBFPm4f77Jklchp7iu/oe0uaB8VeaeBiEueRp3/xOlFLvkPqC', 'USER');
-insert into member_game_info (is_observer, exp, member_game_info_id, member_id, in_game_role, level, nickname, profile_img) values (0,'0','1','1','NONE','BEGINNER','ddd','PROFILE01');
-insert into chat_room (close, capacity, chatroom_id, head, owner_id, password, state, title) values (0, '7', '1', '1', '1', '', 'WAITING', 'dddd');
+insert into member
+(email,is_deleted,member_name,password,role)
+values
+    ('admin@naver.com',0,'admin123','$2a$10$jWpTgBFPm4f77Jklchp7iu/oe0uaB8VeaeBiEueRp3/xOlFLvkPqC', 'USER');
+
+insert into member
+(email,is_deleted,member_name,password,role)
+values
+    ('test1@naver.com',0,'test1','$2a$10$jWpTgBFPm4f77Jklchp7iu/oe0uaB8VeaeBiEueRp3/xOlFLvkPqC', 'USER');
+insert into member
+(email,is_deleted,member_name,password,role)
+values
+    ('test2@naver.com',0,'test2','$2a$10$jWpTgBFPm4f77Jklchp7iu/oe0uaB8VeaeBiEueRp3/xOlFLvkPqC', 'USER');
+insert into member
+(email,is_deleted,member_name,password,role)
+values
+    ('test3@naver.com',0,'test3','$2a$10$jWpTgBFPm4f77Jklchp7iu/oe0uaB8VeaeBiEueRp3/xOlFLvkPqC', 'USER');
+insert into member
+(email,is_deleted,member_name,password,role)
+values
+    ('test4@naver.com',0,'test4','$2a$10$jWpTgBFPm4f77Jklchp7iu/oe0uaB8VeaeBiEueRp3/xOlFLvkPqC', 'USER');
+insert into member
+(email,is_deleted,member_name,password,role)
+values
+    ('test5@naver.com',0,'test5','$2a$10$jWpTgBFPm4f77Jklchp7iu/oe0uaB8VeaeBiEueRp3/xOlFLvkPqC', 'USER');
+insert into member
+(email,is_deleted,member_name,password,role)
+values
+    ('test6@naver.com',0,'test6','$2a$10$jWpTgBFPm4f77Jklchp7iu/oe0uaB8VeaeBiEueRp3/xOlFLvkPqC', 'USER');
+insert into member
+(email,is_deleted,member_name,password,role)
+values
+    ('test7@naver.com',0,'test7','$2a$10$jWpTgBFPm4f77Jklchp7iu/oe0uaB8VeaeBiEueRp3/xOlFLvkPqC', 'USER');
+
+
+insert into member_game_info
+(is_observer, exp, member_game_info_id, member_id, in_game_role, level, nickname, profile_img)
+values
+    (0,'0','1','1','NONE','BEGINNER','admin','PROFILE01');
+insert into member_game_info
+(is_observer, exp, member_game_info_id, member_id, in_game_role, level, nickname, profile_img)
+values
+    (0,'0','2','2','NONE','BEGINNER','test1','PROFILE01');
+insert into member_game_info
+(is_observer, exp, member_game_info_id, member_id, in_game_role, level, nickname, profile_img)
+values
+    (0,'0','3','3','NONE','BEGINNER','test3','PROFILE01');
+insert into member_game_info
+(is_observer, exp, member_game_info_id, member_id, in_game_role, level, nickname, profile_img)
+values
+    (0,'0','4','4','NONE','BEGINNER','test4','PROFILE01');
+insert into member_game_info
+(is_observer, exp, member_game_info_id, member_id, in_game_role, level, nickname, profile_img)
+values
+    (0,'0','5','5','NONE','BEGINNER','test5','PROFILE01');
+insert into member_game_info
+(is_observer, exp, member_game_info_id, member_id, in_game_role, level, nickname, profile_img)
+values
+    (0,'0','6','6','NONE','BEGINNER','test6','PROFILE01');
+insert into member_game_info
+(is_observer, exp, member_game_info_id, member_id, in_game_role, level, nickname, profile_img)
+values
+    (0,'0','7','7','NONE','BEGINNER','test7','PROFILE01');
+
+
+insert into chat_room
+(close, capacity, chatroom_id, head, owner_id, password, state, title)
+values
+    (0, '7', '1', '0', '1', '', 'WAITING', 'mafia');

--- a/src/main/resources/templates/chat-room.html
+++ b/src/main/resources/templates/chat-room.html
@@ -6,240 +6,323 @@
 
 <body onload="connect()">
 <div layout:fragment="header">
-    <nav class="navbar navbar-expand-sm navbar-dark" style="background-color: #666666; height: 10vh;">
-        <!--        <div sec:authorize="isAuthenticated()">-->
-        <a class="navbar-brand" href="#">[[${chatroom.title}]]</a>
+  <nav class="navbar navbar-expand-sm navbar-dark" style="background-color: #666666; height: 10vh;">
+    <!--        <div sec:authorize="isAuthenticated()">-->
+    <a class="navbar-brand" href="#">[[${chatroom.title}]]</a>
 
-        <div class="collapse navbar-collapse" id="navbarTogglerDemo03">
-            <ul class="navbar-nav mr-auto mt-2 mt-lg-0"></ul>
-            <div class="form-inline my-2 my-lg-0">
-                <a class="nav-link text-white" onclick="openRoomDetail()">방 정보</a>
-                <!-- 방 정보 모달-->
-                <div class="modal fade" id="roomDetailModal" tabindex="-1" aria-labelledby="roomDetailModalLabel" aria-hidden="true">
-                    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h1 class="modal-title fs-5" id="roomDetailModalLabel">방 정보</h1>
-                                <!--  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>-->
-                            </div>
-                            <div class="modal-body" th:object="${chatroom}">
-                                <form method="post" action="#">
+    <div class="collapse navbar-collapse" id="navbarTogglerDemo03">
+      <ul class="navbar-nav mr-auto mt-2 mt-lg-0"></ul>
+      <div class="form-inline my-2 my-lg-0">
+        <a class="nav-link text-white" onclick="openRoomDetail()">방 정보</a>
+        <!-- 방 정보 모달-->
+        <div class="modal fade" id="roomDetailModal" tabindex="-1"
+             aria-labelledby="roomDetailModalLabel" aria-hidden="true">
+          <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h1 class="modal-title fs-5" id="roomDetailModalLabel">방 정보</h1>
+                <!--  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>-->
+              </div>
+              <div class="modal-body" th:object="${chatroom}">
+                <form method="post" action="#">
 
-                                    <div class="row">
-                                        <div class="col">
-                                            방 제목
-                                            <input type="text" class="form-control" id="room-title" name="room-name" th:value="${chatroom.title}">
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="col">
-                                            공개 여부
-                                            <input type="button" class="form-control" id="room-close" name="room-close" value="공개방"/>
-                                            <input type="button" class="form-control" id="room-open" name="room-open" value="비밀방">
-                                        </div>
-                                    </div>
-                                    <div class="row" th:if="${chatroom.getPassword() != null}">
-                                        <div class="col">
-                                            비밀 번호
-                                            <input type="text" class="form-control" id="room-password" name="room-password" th:value="${chatroom.getPassword()}">
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="col">
-                                            인원 수
-                                            <input type="text" class="form-control" id="room-capacity" name="room-capacity" th:value="${chatroom.getCapacity()}">
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="col">
-                                            초대 코드
-                                            <p class="form-control" id="room-invite" name="room-invite"></p>
-                                        </div>
-                                    </div>
-
-                                    <!-- 공유하기-->
-                                    <div class="row mb-3">
-                                        <div class="col mx-auto">
-                                            <div class="sns">
-                                                <a href="#n" id="btnKakao" onclick="fn_sendFB('kakaotalk');return false;"
-                                                   class="kakaotalk" target="_self"
-                                                   title="카카오톡 새창열림"><span class="skip">카카오톡</span></a>
-                                                <a href="#n" onclick="handleCopyClipBoard();return false;" th:field="*{id}"
-                                                   class="clipboard" target="_self"
-                                                   title="클립보드 복사"><span class="skip">복사하기</span></a>
-                                            <!--<img id="preview"  alt="Preview" class="rounded-circle shadow" width="200px" height="200px">-->
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <div class="row">
-                                        <div class="col-auto">
-                                            <button class="btn btn-primary" type="submit">저장</button>
-                                        </div>
-                                        <div class="col-auto">
-                                            <button class="btn btn-primary" type="submit">닫기</button>
-                                        </div>
-                                    </div>
-
-                                </form>
-                            </div>
-                        </div>
+                  <div class="row">
+                    <div class="col">
+                      방 제목
+                      <input type="text" class="form-control" id="room-title" name="room-name"
+                             th:value="${chatroom.title}">
                     </div>
-                </div>
-                <!-- 모달 끝 -->
-                <div class="nav-item">
-                    <a class="nav-link text-white" href="#"
-                       th:if="${chatroom.state.getValue() == T(com.springles.domain.constants.ChatRoomCode).WAITING.getValue()}">게임시작</a>
-                    <a class="nav-link text-white" href="#"
-                       th:if="${chatroom.state.getValue() == T(com.springles.domain.constants.ChatRoomCode).PLAYING.getValue()}">내 직업 설명</a>
-                </div>
-                <div class="nav-item">
-                    <a class="nav-link text-white" href="#">게임룰</a>
-                </div>
-                <div class="nav-item">
-                    <a class="nav-link text-white" onclick="location.href='/v1/index'">나가기</a>
-                </div>
+                  </div>
+                  <div class="row">
+                    <div class="col">
+                      공개 여부
+                      <input type="button" class="form-control" id="room-close" name="room-close"
+                             value="공개방"/>
+                      <input type="button" class="form-control" id="room-open" name="room-open"
+                             value="비밀방">
+                    </div>
+                  </div>
+                  <div class="row" th:if="${chatroom.getPassword() != null}">
+                    <div class="col">
+                      비밀 번호
+                      <input type="text" class="form-control" id="room-password"
+                             name="room-password" th:value="${chatroom.getPassword()}">
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="col">
+                      인원 수
+                      <input type="text" class="form-control" id="room-capacity"
+                             name="room-capacity" th:value="${chatroom.getCapacity()}">
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="col">
+                      초대 코드
+                      <p class="form-control" id="room-invite" name="room-invite"></p>
+                    </div>
+                  </div>
+
+                  <!-- 공유하기-->
+                  <div class="row mb-3">
+                    <div class="col mx-auto">
+                      <div class="sns">
+                        <a href="#n" id="btnKakao" onclick="fn_sendFB('kakaotalk');return false;"
+                           class="kakaotalk" target="_self"
+                           title="카카오톡 새창열림"><span class="skip">카카오톡</span></a>
+                        <a href="#n" onclick="handleCopyClipBoard();return false;" th:field="*{id}"
+                           class="clipboard" target="_self"
+                           title="클립보드 복사"><span class="skip">복사하기</span></a>
+                        <!--<img id="preview"  alt="Preview" class="rounded-circle shadow" width="200px" height="200px">-->
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="col-auto">
+                      <button class="btn btn-primary" type="submit">저장</button>
+                    </div>
+                    <div class="col-auto">
+                      <button class="btn btn-primary" type="submit">닫기</button>
+                    </div>
+                  </div>
+
+                </form>
+              </div>
             </div>
+          </div>
         </div>
-    </nav>
+        <!-- 모달 끝 -->
+        <div class="nav-item">
+          <a class="nav-link text-white" href="#"
+             th:if="${chatroom.state.getValue() == T(com.springles.domain.constants.ChatRoomCode).WAITING.getValue()}">게임시작</a>
+          <a class="nav-link text-white" href="#"
+             th:if="${chatroom.state.getValue() == T(com.springles.domain.constants.ChatRoomCode).PLAYING.getValue()}">내
+            직업 설명</a>
+        </div>
+        <div class="nav-item">
+          <a class="nav-link text-white" href="#">게임룰</a>
+        </div>
+        <div class="nav-item">
+          <a class="nav-link text-white" onclick="">나가기</a>
+        </div>
+      </div>
+    </div>
+  </nav>
 </div>
 
 <div layout:fragment="content">
 
-    <div class="row" style="border-radius: 10px;
+  <div class="row" style="border-radius: 10px;
     border: solid 1px silver;
     margin: 4vw;
     padding: 0;
     height: 80vh">
-        <div class="col-3" style="height:100%; background-color: gray; padding:20px">
-            <!---------------참여인원 / 정원 -------------------->
-            <h3>참여자</h3>
-            <span th:text="${chatroom.getHead()}"></span>/<span th:text="${chatroom.getCapacity()}"></span>
-            <div>
-                <!--------------참여자 목록 ------------------------>
-                <div>사람 이름이 여기 나와야하눈뎅,,</div>
-                <div th:each="player : ${players}">
-                    <div th:text="${player.getMemberId()}"></div>
-                    <div th:text="${player.getRole()}"></div>
-                </div>
-            </div>
-        </div>
-        <!------------------- 채팅----------------------------------------------------------------------------------->
-        <div class="col-9" style="padding:0; height:80%">
-            <!----------채팅 화면 스크롤 ----------------->
-            <div id="conversationDiv">
-                <div class="chat_ui">
-                    <a href="/chat"></a>
-                    <p id="response"></p>
-                </div>
-                <!---------채팅 입력 input ----------------->
-                <form class="container row" id="message-form">
-                    <input class="chat_input_ui col-11" style="margin:0;" type="text" id="message" placeholder="Write a message..."/>
-                    <button class="col-1 btn btn-primary" style="margin: 0 0 4px; width:75px" type="submit">보내기
-                    </button>
-                </form>
-            </div>
-        </div>
+    <div class="col-3" style="height:100%; background-color: gray; padding:20px">
+      <!---------------참여인원 / 정원 -------------------->
+      <h3>참여자</h3>
+      <span id="gamePlayer"></span>/
+      <span id="gameCapacity"></span>
+      <div id="playerList">
+        <!--------------참여자 목록 ------------------------>
+        <!--<div th:each="player : ${players}">
+          <div th:text="${player.getMemberId()}"></div>
+          <div th:text="${player.getRole()}"></div>
+        </div>-->
+      </div>
     </div>
+    <!------------------- 채팅----------------------------------------------------------------------------------->
+    <div class="col-9" style="padding:0; height:80%">
+      <!----------채팅 화면 스크롤 ----------------->
+      <div id="conversationDiv">
+        <div class="chat_ui">
+          <a href="/chat"></a>
+          <p id="response"></p>
+        </div>
+        <!---------채팅 입력 input ----------------->
+        <form class="container row" id="message-form">
+          <input class="chat_input_ui col-11" style="margin:0;" type="text" id="message"
+                 placeholder="Write a message..."/>
+          <button class="col-1 btn btn-primary" style="margin: 0 0 4px; width:75px" type="submit">
+            보내기
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
-    <script src="//developers.kakao.com/sdk/js/kakao.min.js"></script>
-    <script src="/js/stomp.js"></script>
-    <script type="text/javascript">
-        let stompClient = null;
-        const pathname = window.location.pathname;
-        const roomId = parseInt(pathname.split("/")[2]);
-        const nickname = decodeURI(pathname.split("/")[3]);
+  <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+  <script src="//developers.kakao.com/sdk/js/kakao.min.js"></script>
+  <script src="/js/stomp.js"></script>
+  <script type="text/javascript">
+    let stompClient = null;
+    let pathname = window.location.pathname;
+    let roomId = parseInt(pathname.split("/")[2]);
+    let nickname = decodeURI(pathname.split("/")[3]);
 
-        function getRoomName() {
-            fetch(`/chat/rooms/${roomId}/${nickname}`).then((response) => {
-                response.json().then((responseBody) => {
-                    console.log("GetRoomName 결과: "+responseBody);
-                    document.getElementById('room-name').innerHTML = responseBody.roomName;
-                })
-            });
-        }
+    function getRoomName() {
+      fetch(`/v1/chatRooms/${roomId}`).then((response) => {
+        response.json().then((responseBody) => {
+          console.log(responseBody)
+          document.getElementById('gameCapacity').innerHTML = responseBody.capacity;
+        })
+      });
+    }
 
-        function connect() {
-            getRoomName();
-            const socket = new WebSocket('ws://localhost:8080/chatting');
-            stompClient = Stomp.over(socket);
-            stompClient.connect({}, function(frame) {
-                console.log('Connected: ' + frame);
-                stompClient.subscribe(`/sub/chat/${roomId}`, (message) => {
-                    console.log("메시지: " + JSON.parse(message.body))
-                    receiveMessage(JSON.parse(message.body));
-                });
-                stompClient.subscribe(`/sub/chat/${roomId}/playerList`, function (message){
-                    // 채팅방 참여자 목록 갱신
-                })
-            });
-        }
+    function connect() {
+      getRoomName();
+      const socket = new WebSocket('ws://localhost:8080/chatting');
+      stompClient = Stomp.over(socket);
+      stompClient.connect({}, function (frame) {
+        console.log('Connected: ' + frame);
 
-        function receiveMessage(messageOutput) {
-            const response = document.getElementById('response');
-            console.log(response)
-            const p = document.createElement('p');
-            p.style.wordWrap = 'break-word';
-            p.appendChild(document.createTextNode(
-                " (" + messageOutput.time + ") "
-                +messageOutput.sender
-                + ": "
-                + messageOutput.message));
-            response.appendChild(p);
-        }
+        // 게임 참여 메시지 전송
+        stompClient.send(`/pub/gameJoin/${roomId}`)
 
-        document.getElementById("message-form").addEventListener("submit", (event) => {
-            event.preventDefault()
-            const messageInput = document.getElementById('message');
-            const message = messageInput.value
-            stompClient.send(`/pub/chat/${roomId}`, {
-                    "Authorization": "Bearer Token_here"
-                },message);
-            messageInput.value = null
+        // 전체 채팅 URL 구독
+        stompClient.subscribe(`/sub/chat/${roomId}`, (message) => {
+          const body = JSON.parse(message.body)
+          console.log("전체 메시지: ")
+          receiveMessage(body);
+        });
+
+        // 채팅방 목록 URL 구독
+        stompClient.subscribe(`/sub/chat/${roomId}/playerList`, function (message) {
+          updatePlayerList(message)
         })
 
-        function openRoomDetail() {
-            $('#roomDetailModal').modal('show'); // 모달 열기
+        // 개인 채팅 URL 구독
+        stompClient.subscribe(`/sub/chat/${roomId}/${nickname}`, (message) => {
+          const body = JSON.parse(message.body)
+          console.log("개인 메시지: " + body)
+          receiveMessage(body);
+        })
+
+        // 게임 시작 시 역할 부여 URL 구독
+        stompClient.subscribe(`/sub/chat/${roomId}/gameRole/${nickname}`, (message => {
+          const body = JSON.parse(message.body)
+          console.log("역할 설명 메시지: " + body)
+          stompClient.subscribe(`/sub/chat/${roomId}/${body.gameRole}`)
+          stompClient.unsubscribe(`/sub/chat/${roomId}/playerRole/${nickname}`)
+          receiveMessage(body)
+        }))
+
+      });
+    }
+
+    // 브라우저 변동 시 게임 나가기
+    // 새로고침시 나갔다가 들어온 것으로 간주
+    window.addEventListener('beforeunload', (event) => {
+      event.preventDefault();
+      stompClient.send(`/pub/gameExit/${roomId}`)
+    });
+
+    function updatePlayerList(message) {
+      const list = document.getElementById('playerList');
+      list.innerHTML = ""
+      let i = 0
+      for (const player of JSON.parse(message.body)) {
+        const li = document.createElement('li');
+        li.appendChild(document.createTextNode(
+            "[" + player.memberName + "]"
+        ))
+        i++;
+        list.appendChild(li)
+      }
+      document.getElementById('gamePlayer').innerText = i;
+    }
+
+    function gameStart() {
+      stompClient.send(`/pub/gameStart/${roomId}`)
+    }
+
+    function gameExit() {
+      stompClient.send(`/pub/gameExit/${roomId}`)
+      stompClient.disconnect();
+      location.href = '/v1/index';
+    }
+
+    function receiveMessage(messageOutput) {
+      const response = document.getElementById('response');
+      console.log(response)
+      const p = document.createElement('p');
+      p.style.wordWrap = 'break-word';
+      p.appendChild(document.createTextNode(
+          " (" + messageOutput.time + ") "
+          + messageOutput.sender
+          + ": "
+          + messageOutput.message));
+      response.appendChild(p);
+    }
+
+    document.getElementById("message-form").addEventListener("submit", (event) => {
+      event.preventDefault()
+      const messageInput = document.getElementById('message');
+      const message = messageInput.value
+      stompClient.send(`/pub/chat/${roomId}`, {
+        "Authorization": getCookie("accessToken")
+      }, message);
+      messageInput.value = null
+    })
+
+    function openRoomDetail() {
+      $('#roomDetailModal').modal('show'); // 모달 열기
+    }
+
+    const snsTitle = "챗피아에서 게임하기";
+    const thisUrl = window.location.href;
+    console.log("thisUrl", thisUrl)
+    const handleCopyClipBoard = async () => {
+      try {
+        await navigator.clipboard.writeText(thisUrl);
+        alert('클립보드에 링크가 복사되었습니다.');
+      } catch (e) {
+        alert('복사에 실패하였습니다');
+      }
+    };
+
+    function getCookie(cookieName) {
+      var name = cookieName + "=";
+      var decodedCookie = decodeURIComponent(document.cookie);
+      var cookieArray = decodedCookie.split(';');
+
+      for (var i = 0; i < cookieArray.length; i++) {
+        var cookie = cookieArray[i];
+        while (cookie.charAt(0) === ' ') {
+          cookie = cookie.substring(1);
         }
-
-        const snsTitle = "챗피아에서 게임하기";
-        const thisUrl =  window.location.href;
-        console.log("thisUrl", thisUrl)
-        const handleCopyClipBoard = async () => {
-            try {
-                await navigator.clipboard.writeText(thisUrl);
-                alert('클립보드에 링크가 복사되었습니다.');
-            } catch (e) {
-                alert('복사에 실패하였습니다');
-            }
-        };
-
-        function fn_sendFB(sns) {
-
-            <!-- 카카오  -->
-            if (sns == 'kakaotalk') {
-                // 사용할 앱의 JavaScript 키 설정
-                Kakao.init('1f068199be43767b197138dfc91f1cb6');
-
-                // 카카오링크 버튼 생성
-                Kakao.Link.createDefaultButton({
-                    container: '#btnKakao', // HTML에서 작성한 ID값
-                    objectType: 'feed',
-                    content: {
-                        title: snsTitle, // 보여질 제목
-                        description: snsTitle, // 보여질 설명
-                        imageUrl: thisUrl, // 카카오공유하기 시 썸네일 이미지 경로
-                        link: { //  카카오공유하기 시 클릭 후 이동 경로
-                            mobileWebUrl: thisUrl,
-                            webUrl: thisUrl
-                        }
-                    }
-                });
-            }
+        if (cookie.indexOf(name) === 0) {
+          return cookie.substring(name.length, cookie.length);
         }
+      }
+      return "";
+    }
 
-    </script>
+    function fn_sendFB(sns) {
+
+      <!-- 카카오  -->
+      if (sns == 'kakaotalk') {
+        // 사용할 앱의 JavaScript 키 설정
+        Kakao.init('1f068199be43767b197138dfc91f1cb6');
+
+        // 카카오링크 버튼 생성
+        Kakao.Link.createDefaultButton({
+          container: '#btnKakao', // HTML에서 작성한 ID값
+          objectType: 'feed',
+          content: {
+            title: snsTitle, // 보여질 제목
+            description: snsTitle, // 보여질 설명
+            imageUrl: thisUrl, // 카카오공유하기 시 썸네일 이미지 경로
+            link: { //  카카오공유하기 시 클릭 후 이동 경로
+              mobileWebUrl: thisUrl,
+              webUrl: thisUrl
+            }
+          }
+        });
+      }
+    }
+
+  </script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/home/add.html
+++ b/src/main/resources/templates/home/add.html
@@ -84,9 +84,9 @@
                         success: function(data) {
                             stompClient.send(`/pub/gameCreate/${data.data.id}`)
                             // response data에서 방장 이름 가져오기
-                            const nickName = response.data.nickName;
+                            const nickName = data.data.nickName;
                             // response data에서 roomId 가져오기
-                            const roomId = response.data.id;
+                            const roomId = data.data.id;
                             // 성공할 경우 해당 채팅방으로 바로 이동
                             location.replace('http://localhost:8080/chat/'+roomId+'/'+nickName);
                         },


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
close #177 

###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- a57d8d3860416c559d0ac820dde8bbcab6cb3d1d : 희수님의 더미데이터를 추가했습니다.
- b3e89caabf61edc9fcf8ad5b1da2bd0593254cb2 : 채팅방 정보를 조회하는 API가 없어서 추가했습니다.
- 5de23947a19202483fd07ce8ceea861bbea27d3d : 
  - 채팅방 입장, 퇴장 시 Admin 메시지가 출력되도록 설정하였습니다. 
  - 브라우저 변동 감지 이벤트를 추가하여 새로고침, 브라우저 닫기, 게임 나가기 이벤트 시 참여자 목록이 조정되는 기능을 추가했습니다.
  - 참여자 목록이 실시간으로 변동되도록 구성하였습니다.
  - 채팅방 정보를 가져오는 API가 게임에 참여하면 호출되어 이를 이용해 앞으로 게임 정보를 불러올 수 있습니다.


## 📷 스크린샷

## 👀 기타
- (!!중요) 테스트를 진행하실 때에는 항상 docker에서 redis 데이터를 지우고 진행하셔야 합니다.
- 또한, 더미데이터에서 생성되는 채팅방은 게임세션이 없는 상태이기 때문에 이용하지 마시고 새로 채팅방을 만들어서 입장하셔야 합니다.
```
redis-cli (redis 터미널 접속)
keys * (현재 있는 데이터 조회)
flushall (모든 데이터 삭제) ->  테스트 진행하실 때마다 항상 이 명령어를 호출하셔야 합니다.
```
