### PR TITLE
Fix/#200 jwt token filter logic

### DIFF
--- a/src/main/java/com/springles/config/WebSecurityConfig.java
+++ b/src/main/java/com/springles/config/WebSecurityConfig.java
@@ -34,22 +34,21 @@ public class WebSecurityConfig implements WebMvcConfigurer {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(
                         authHttp -> authHttp
-                                /** 아래 API를 제외한 나머지에 대해서는 인증이 필요 없도록 임시 세팅 (*추후 개발 완료 시 '실제 권한 코드'로 변경 필요) */
-                                .requestMatchers(new AntPathRequestMatcher("/member/updateInfo")).authenticated()
-                                .requestMatchers(new AntPathRequestMatcher("/member/signOut")).authenticated()
-                                .requestMatchers(new AntPathRequestMatcher("/member/logout")).authenticated()
-                                .requestMatchers(new AntPathRequestMatcher("/info/profile")).authenticated()
-                                .requestMatchers(new AntPathRequestMatcher("/record", "GET")).authenticated()
-                                .anyRequest().permitAll()
                                 /** 실제 권한 코드 */
-//                                .requestMatchers(new AntPathRequestMatcher("/v1/signup")).permitAll()
-//                                .requestMatchers(new AntPathRequestMatcher("/member/signup")).permitAll()
-//                                .requestMatchers(new AntPathRequestMatcher("/v1/login-page")).permitAll()
-//                                .requestMatchers(new AntPathRequestMatcher("/v1/login")).permitAll()
-//                                .requestMatchers(new AntPathRequestMatcher("/member/login")).permitAll()
-//                                .requestMatchers(new AntPathRequestMatcher("/v1/login-page?error")).permitAll()
-//                                .requestMatchers(new AntPathRequestMatcher("/css/*")).permitAll()
-//                                .anyRequest().authenticated()
+                                // 회원가입, 로그인, 아이디/비밀번호 찾기 api·ui
+                                .requestMatchers(new AntPathRequestMatcher("/v1/signup")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/v1/login")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/v1/login-page")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/v1/login-page?error")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/v1/vertification-id")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/v1/vertification-pw")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/member/signup")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/member/login")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/member/vertification/id")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/member/vertification/pw")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/css/*")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/images/*")).permitAll()
+                                .anyRequest().authenticated()
                 )
                 .formLogin(
                         login -> login

--- a/src/main/java/com/springles/controller/api/ChatRoomController.java
+++ b/src/main/java/com/springles/controller/api/ChatRoomController.java
@@ -7,6 +7,7 @@ import com.springles.domain.dto.chatroom.ChatRoomUpdateReqDto;
 import com.springles.domain.dto.member.MemberCreateRequest;
 import com.springles.domain.dto.member.MemberInfoResponse;
 import com.springles.domain.dto.response.ResResult;
+import com.springles.jwt.JwtTokenUtils;
 import com.springles.service.ChatRoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,13 +27,14 @@ public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
     private final MemberUiController memberUiController;
+    private final JwtTokenUtils jwtTokenUtils;
 
     // 채팅방 생성
     @Operation(summary = "채팅방 생성", description = "채팅방 생성")
     @PostMapping(value = "/chatrooms")
     public ResponseEntity<ResResult> createChatRoom(@Valid @RequestBody ChatRoomReqDTO chatRoomReqDTO, HttpServletRequest request, Authentication auth){
 
-        String accessToken = (String) request.getAttribute("accessToken");
+        String accessToken = jwtTokenUtils.atkFromCookie(request);
         MemberInfoResponse info = memberUiController.info(accessToken);
         Long id = info.getId();
         String memberName = info.getMemberName();

--- a/src/main/java/com/springles/controller/api/MemberController.java
+++ b/src/main/java/com/springles/controller/api/MemberController.java
@@ -3,6 +3,7 @@ package com.springles.controller.api;
 import com.springles.domain.constants.ResponseCode;
 import com.springles.domain.dto.member.*;
 import com.springles.domain.dto.response.ResResult;
+import com.springles.jwt.JwtTokenUtils;
 import com.springles.service.MemberService;
 import com.springles.valid.ValidationSequence;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final JwtTokenUtils jwtTokenUtils;
 
     // 회원가입
     @PostMapping("/signup")
@@ -42,7 +44,7 @@ public class MemberController {
             @Validated({ValidationSequence.class}) @RequestBody MemberUpdateRequest memberDto,
             HttpServletRequest request
     ) {
-        String accessToken = (String) request.getAttribute("accessToken");
+        String accessToken = jwtTokenUtils.atkFromCookie(request);
         ResponseCode responseCode = ResponseCode.MEMBER_UPDATE;
 
         return ResponseEntity.ok(
@@ -61,7 +63,7 @@ public class MemberController {
             @Validated({ValidationSequence.class}) @RequestBody MemberDeleteRequest memberDto,
             HttpServletRequest request
     ) {
-        String accessToken = (String) request.getAttribute("accessToken");
+        String accessToken = jwtTokenUtils.atkFromCookie(request);
         memberService.signOut(memberDto, accessToken);
         ResponseCode responseCode = ResponseCode.MEMBER_DELETE;
 
@@ -97,7 +99,7 @@ public class MemberController {
     public ResponseEntity<ResResult> logout(
             HttpServletRequest request
     ) {
-        String accessToken = (String) request.getAttribute("accessToken");
+        String accessToken = jwtTokenUtils.atkFromCookie(request);
         ResponseCode responseCode = ResponseCode.MEMBER_LOGOUT;
         memberService.logout(accessToken);
 
@@ -153,7 +155,7 @@ public class MemberController {
             @Validated({ValidationSequence.class}) @RequestBody MemberProfileCreateRequest memberDto,
             HttpServletRequest request
     ) {
-        String accessToken = (String) request.getAttribute("accessToken");
+        String accessToken = jwtTokenUtils.atkFromCookie(request);
         ResponseCode responseCode = ResponseCode.MEMBER_PROFILE_CREATE;
 
         return ResponseEntity.ok(
@@ -173,7 +175,7 @@ public class MemberController {
             @Validated({ValidationSequence.class}) @RequestBody MemberProfileUpdateRequest memberDto,
             HttpServletRequest request
     ) {
-        String accessToken = (String) request.getAttribute("accessToken");
+        String accessToken = jwtTokenUtils.atkFromCookie(request);
         ResponseCode responseCode = ResponseCode.MEMBER_PROFILE_UPDATE;
 
         return ResponseEntity.ok(

--- a/src/main/java/com/springles/controller/ui/ChatRoomUiController.java
+++ b/src/main/java/com/springles/controller/ui/ChatRoomUiController.java
@@ -6,6 +6,7 @@ import com.springles.domain.dto.chatroom.ChatRoomResponseDto;
 import com.springles.domain.dto.member.MemberInfoResponse;
 import com.springles.domain.dto.member.MemberProfileResponse;
 import com.springles.exception.CustomException;
+import com.springles.jwt.JwtTokenUtils;
 import com.springles.service.ChatRoomService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -26,6 +27,7 @@ public class ChatRoomUiController {
 
     private final MemberUiController memberUiController;
     private final ChatRoomService chatRoomService;
+    private final JwtTokenUtils jwtTokenUtils;
 
     // 홈으로 가는 controller : addAttribute 로 username 을 전달 해주고 있다.
 //    @GetMapping("/detail.html")
@@ -66,7 +68,7 @@ public class ChatRoomUiController {
     ) {
 
         // 목록 전체 조회
-        String accessToken = (String)request.getAttribute("accessToken");
+        String accessToken = jwtTokenUtils.atkFromCookie(request);
 
         // 회원 정보 호출
 //        MemberInfoResponse info = memberUiController.info(accessToken);

--- a/src/main/java/com/springles/controller/ui/ChatUiController.java
+++ b/src/main/java/com/springles/controller/ui/ChatUiController.java
@@ -7,6 +7,7 @@ import com.springles.domain.entity.Player;
 import com.springles.exception.CustomException;
 import com.springles.exception.constants.ErrorCode;
 import com.springles.game.GameSessionManager;
+import com.springles.jwt.JwtTokenUtils;
 import com.springles.service.ChatRoomService;
 import com.springles.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -31,6 +32,7 @@ public class ChatUiController {
     private final MemberService memberService;
     private final MemberUiController memberUiController;
     private final GameSessionManager gameSessionManager;
+    private final JwtTokenUtils jwtTokenUtils;
 
     @GetMapping("rooms")
     public String rooms() {
@@ -58,7 +60,7 @@ public class ChatUiController {
                             HttpServletRequest request, Model model){
 
         // 멤버 정보
-        String accessToken = (String)request.getAttribute("accessToken");
+        String accessToken = jwtTokenUtils.atkFromCookie(request);
         MemberInfoResponse memberInfo = memberUiController.info(accessToken);
         model.addAttribute("member",memberInfo);
 
@@ -100,7 +102,7 @@ public class ChatUiController {
     @GetMapping("quick-enter")
     public String quickEnterRoom( HttpServletRequest request, Model model){
 
-        String accessToken = (String)request.getAttribute("accessToken");
+        String accessToken = jwtTokenUtils.atkFromCookie(request);
         MemberInfoResponse memberInfo = memberUiController.info(accessToken);
 
         model.addAttribute("member",memberInfo);

--- a/src/main/java/com/springles/controller/ui/MemberUiController.java
+++ b/src/main/java/com/springles/controller/ui/MemberUiController.java
@@ -161,10 +161,9 @@ public class MemberUiController {
         Cookie cookie = new Cookie(name, value);
         cookie.setDomain("localhost");
         cookie.setPath("/");
-//        cookie.setMaxAge(60 * 60);  // 1시간(테스트용)
-        cookie.setMaxAge(30);  // 1시간(테스트용)
+        cookie.setMaxAge(60 * 60);  // 1시간(테스트용)
         cookie.setHttpOnly(true);
-        cookie.setSecure(true);
+//        cookie.setSecure(true);   // 사파리 브라우저에서 쿠키 저장이 안되는 이슈 해결을 위해 설정 해제
         response.addCookie(cookie);
     }
 
@@ -174,10 +173,9 @@ public class MemberUiController {
         Cookie cookie = new Cookie(name, value);
         cookie.setDomain("localhost");
         cookie.setPath("/");
-//        cookie.setMaxAge(60 * 60 * 24 * 14);    // 2주
         cookie.setMaxAge(60 * 60 * 24 * 14);    // 2주
         cookie.setHttpOnly(true);
-        cookie.setSecure(true);
+//        cookie.setSecure(true);   // 사파리 브라우저에서 쿠키 저장이 안되는 이슈 해결을 위해 설정 해제
         response.addCookie(cookie);
     }
 }

--- a/src/main/java/com/springles/controller/ui/MemberUiController.java
+++ b/src/main/java/com/springles/controller/ui/MemberUiController.java
@@ -1,6 +1,9 @@
 package com.springles.controller.ui;
 
 import com.springles.domain.dto.member.*;
+import com.springles.exception.CustomException;
+import com.springles.exception.constants.ErrorCode;
+import com.springles.jwt.JwtTokenUtils;
 import com.springles.repository.MemberGameInfoJpaRepository;
 import com.springles.service.MemberService;
 import com.springles.valid.ValidationSequence;
@@ -24,6 +27,7 @@ public class MemberUiController {
 
     private final MemberService memberService;
     private final MemberGameInfoJpaRepository memberGameInfoJpaRepository;
+    private final JwtTokenUtils jwtTokenUtils;
 
     // 회원가입 페이지 조회
     @GetMapping("/signup")
@@ -82,7 +86,7 @@ public class MemberUiController {
             HttpServletRequest request
     ) {
         // accessToken 추출
-        String accessToken = (String) request.getAttribute("accessToken");
+        String accessToken = jwtTokenUtils.atkFromCookie(request);
 
         // 프로필 조회
         MemberProfileRead profileInfo = memberService.readProfile(accessToken);
@@ -96,17 +100,15 @@ public class MemberUiController {
         return "member/my-page";
     }
 
+
     // 회원 정보 변경 페이지 조회
     @GetMapping("/my-page/info")
     public String memberInfo(
             Model model,
-            @ModelAttribute("memberInfo") MemberUpdateRequest memberDto,
             HttpServletRequest request
     ) {
-        String accessToken = (String) request.getAttribute("accessToken");
+        String accessToken = jwtTokenUtils.atkFromCookie(request);
         MemberInfoResponse memberInfo = memberService.getUserInfo(accessToken);
-
-        model.addAttribute("memberInfo", memberDto);
         model.addAttribute("rawMemberInfo", memberInfo);
 
         return "member/member-info";
@@ -114,23 +116,14 @@ public class MemberUiController {
 
     // 회원 탈퇴 페이지 조회
     @GetMapping("/my-page/sign-out")
-    public String signOut(
-            Model model,
-            @ModelAttribute("member") MemberDeleteRequest memberDto,
-            HttpServletRequest request
-    ) {
-        model.addAttribute("member", memberDto);
+    public String signOut() {
         return "member/member-sign-out";
     }
 
 
     // 프로필 설정 페이지 조회
     @GetMapping("/profile-settings")
-    public String profileSetting(
-            Model model,
-            @ModelAttribute("member") MemberProfileCreateRequest memberDto
-    ) {
-        model.addAttribute("member", memberDto);
+    public String profileSetting() {
         return "member/profile-settings";
     }
 
@@ -142,11 +135,9 @@ public class MemberUiController {
             @ModelAttribute("profile") MemberProfileUpdateRequest memberDto,
             HttpServletRequest request
     ) {
-        // accessToken 추출
-        String accessToken = (String) request.getAttribute("accessToken");
+        String accessToken = jwtTokenUtils.atkFromCookie(request);
         MemberProfileRead rawProfile = memberService.readProfile(accessToken);
 
-        model.addAttribute("profile", memberDto);
         model.addAttribute("rawProfile", rawProfile);
         return "member/profile-change";
     }
@@ -170,7 +161,8 @@ public class MemberUiController {
         Cookie cookie = new Cookie(name, value);
         cookie.setDomain("localhost");
         cookie.setPath("/");
-        cookie.setMaxAge(60 * 60);  // 1시간(테스트용)
+//        cookie.setMaxAge(60 * 60);  // 1시간(테스트용)
+        cookie.setMaxAge(30);  // 1시간(테스트용)
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         response.addCookie(cookie);
@@ -182,6 +174,7 @@ public class MemberUiController {
         Cookie cookie = new Cookie(name, value);
         cookie.setDomain("localhost");
         cookie.setPath("/");
+//        cookie.setMaxAge(60 * 60 * 24 * 14);    // 2주
         cookie.setMaxAge(60 * 60 * 24 * 14);    // 2주
         cookie.setHttpOnly(true);
         cookie.setSecure(true);

--- a/src/main/java/com/springles/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/springles/jwt/JwtTokenFilter.java
@@ -18,7 +18,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 
 @Slf4j
 @Component
@@ -26,8 +28,7 @@ import java.util.ArrayList;
 public class JwtTokenFilter extends OncePerRequestFilter {
 
     private final JwtTokenUtils jwtTokenUtils;
-    private String accessToken = "";
-    private String refreshTokenId = "";
+
 
     @Override
     protected void doFilterInternal(
@@ -36,129 +37,244 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
 
+        String accessToken = "";
+        String refreshTokenId = "";
+
         Cookie[] cookies = request.getCookies();
 
-        /** 쿠키에서 accessToken과 refreshTokenId 추출 */
+        log.info(request.getRequestURI());
+
+        /**
+         *  쿠키에서 accessToken(atk), refreshToken(rtk) 추출
+         *  */
         if (cookies != null) {
-            log.info("쿠키 != null");
+            log.info("쿠키 있음");
 
             for (Cookie cookie : cookies) {
+
+                // 쿠키에 atk가 있는지 확인
                 if ("accessToken".equals(cookie.getName())) {
                     accessToken = cookie.getValue();
-                    request.setAttribute("accessToken", accessToken);
-                }
-                if ("refreshTokenId".equals(cookie.getName())) {
+                    log.info("쿠키에 atk 있음");
+                    log.info("atk: " + accessToken);
+                    // 혹은 쿠키에 rtk가 있는지 확인
+                } else if ("refreshTokenId".equals(cookie.getName())) {
                     refreshTokenId = cookie.getValue();
+                    log.info("쿠키에 rtk 있음");
+                    log.info("rtk: " + refreshTokenId);
                 }
             }
+        } else {
+            /*
+             * [쿠키가 null이면 인증 절차를 거치지 않음]
+             * 권한이 필요한 api일 경우, 로그인 화면으로 이동
+             * 권한이 필요 없는 api일 경우, 화면 정상 출력
+             */
+        }
 
-            /**  쿠키에 accessToken이 존재할 경우 */
-            if (!accessToken.equals("")) {
-                log.info("쿠키에 accessToken이 존재");
 
-                // accessToken 로그아웃 여부 체크
-                if (jwtTokenUtils.isNotLogout(accessToken)) {
-                    log.info("로그아웃 안됨");
+        /**
+         *  토큰 존재유무/유효성 판별
+         *  */
+        // 쿠키에 atk가 있는지 확인
+        if (!accessToken.equals("")) {
 
-                    /* accessToken 유효성 체크
-                     * 0 : 유효하지 않은 JWT 서명, 지원되지 않는 JWT토큰, 잘못된 JWT 토큰
-                     * 1 : 유효한 토큰
-                     * 2 : 유효기간이 만료된 토큰
-                     * */
-                    if (jwtTokenUtils.validate(accessToken) != 0) {
-                        log.info("validate(accessToken) != 0");
+            // atk가 로그아웃 됐는지 확인
+            if (jwtTokenUtils.isNotLogout(accessToken)) {
+                log.info("로그아웃 안됨");
 
-                        // accessToken 유효기간 만료 or 짧게 남음 체크
-                        if ((jwtTokenUtils.validate(accessToken) == 2)
-//                                || ((jwtTokenUtils.parseClaims(accessToken).getExpiration().getTime() - Date.from(Instant.now()).getTime()) / 1000) < 30L
-                        ) {
-                            log.info("유효기간 만료 or 적게남음");
+                // atk가 정상인지 확인(서명 등)
+                if (jwtTokenUtils.validate(accessToken) == 1) {
+                    log.info("atk valid 정상");
 
-                            // refreshTokenId가 있을 경우
-                            if (!refreshTokenId.equals("")) {
-                                // accessToken 갱신
-                                // 만약 refreshToken이 DB에 존재하거나 유효하지 않을 경우 jwtTokenUtils.reissue() 메소드에서 ""가 반환됨(유효x)
-                                accessToken = jwtTokenUtils.reissue(refreshTokenId);
+                    // atk의 유효시간이 적게 남았는지 확인
+                    if(((jwtTokenUtils.parseClaims(accessToken).getExpiration().getTime() - Date.from(Instant.now()).getTime()) / 1000) < 30L) {
+                        // rtk가 추출되었는지 확인
+                        if (!refreshTokenId.equals("")) {
 
-                                // 갱신한 accessToken이 유효한지 체크
-                                if (!accessToken.equals("")) {
-                                    // accessToken 재발급 후 쿠키, attribute에 저장
-                                    jwtTokenUtils.setAtkCookie("accessToken", accessToken, response);
-                                    request.setAttribute("accessToken", accessToken);
-                                    log.info("accessToken 재발급 완료");
-                                }
+                            // atk 재발급
+                            accessToken = jwtTokenUtils.reissue(refreshTokenId);
 
-                                // refreshToken이 DB 상에 존재하지 않거나 유효하지 않는 경우
-                                // (쿠키에는 있었으나 로직을 수행하는 사이 refreshToken의 유효시간이 지나서 DB에서 삭제된 경우)
-                                else {
-                                    log.info("refreshToken이 DB에 존재하지 않거나 유효하지 않음");
-                                    throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
-                                }
-                            }
+                            // atk 값이 비어있지 않은지 확인
+                            // 재발급을 했는데도 불구하고 값이 비어있으면 rtk가 비정상인 것
+                            if (!accessToken.equals("")) {
+                                // atk가 정상
+                                log.info("atk 재발급 완료");
 
-                            // 쿠키에 refreshTokenId가 없을 경우
-                            else {
-                                log.info("refreshToken이 쿠키에 존재하지 않음");
+                                // 쿠키에 저장
+                                jwtTokenUtils.setAtkCookie("accessToken", accessToken, response);
+                                log.info("atk 쿠키에 저장 완료");
+
+                            } else {
+                                // atk 값이 비어있을 경우
+                                log.info("rtk 비정상, 재발급 불가");
+
+                                // 현재 rtk 쿠키 초기화
+                                refreshTokenId = "";
+                                accessToken = "";
+
+                                // rtk 쿠키 삭제
+                                jwtTokenUtils.setInitTokenCookie("refreshTokenId", null, response);
+                                jwtTokenUtils.setInitTokenCookie("accessToken", null, response);
+
+                                // 예외 처리(로그인 화면으로 이동)
                                 throw new CustomException(ErrorCode.NO_JWT_TOKEN);
                             }
+                        } else {
+                            /*
+                             * rtk가 없다면 atk 재발급하지 않고 인증 진행
+                             */
                         }
                     }
-                    // accessToken이 유효하지 않을 경우
-                    else {
-                        log.info("accessToken이 유효하지 않음");
+
+                    // 인증객체 생성
+                    log.info("인증객체 생성");
+                    SecurityContext context = SecurityContextHolder.createEmptyContext();
+                    String memberName = jwtTokenUtils.parseClaims(accessToken).getSubject();
+                    log.info("memberName : " + memberName );
+
+                    AbstractAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                            MemberCreateRequest.builder()
+                                    .memberName(memberName)
+                                    .build(),
+                            accessToken, new ArrayList<>()
+                    );
+                    context.setAuthentication(authenticationToken);
+                    SecurityContextHolder.setContext(context);
+                }
+                // atk가 정상이 아닐 경우
+                else {
+                    // 현재 atk 초기화
+                    accessToken = "";
+                    log.info("atk valid 비정상");
+                    log.info("atk : " + accessToken);
+
+                    // atk 쿠키 삭제
+                    jwtTokenUtils.setInitTokenCookie("accessToken", null, response);
+
+                    // atk의 유효기간이 만료된 거였다면 rtk 확인
+                    if (jwtTokenUtils.validate(accessToken) == 2) {
+                        log.info("atk valid 비정상 - 유효기간 만료");
+
+                        // rtk가 추출되었는지 확인
+                        if (!refreshTokenId.equals("")) {
+
+                            // atk 재발급
+                            accessToken = jwtTokenUtils.reissue(refreshTokenId);
+
+                            // atk 값이 비어있지 않은지 확인
+                            // 재발급을 했는데도 불구하고 값이 비어있으면 rtk가 비정상인 것
+                            if (!accessToken.equals("")) {
+                                // atk가 정상
+                                log.info("atk 재발급 완료");
+
+                                // 쿠키에 저장
+                                jwtTokenUtils.setAtkCookie("accessToken", accessToken, response);
+
+                                // 인증객체 생성
+                                SecurityContext context = SecurityContextHolder.createEmptyContext();
+                                String memberName = jwtTokenUtils.parseClaims(accessToken).getSubject();
+
+                                AbstractAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                                        MemberCreateRequest.builder()
+                                                .memberName(memberName)
+                                                .build(),
+                                        accessToken, new ArrayList<>()
+                                );
+                                context.setAuthentication(authenticationToken);
+                                SecurityContextHolder.setContext(context);
+
+                            } else {
+                                // atk 값이 비어있을 경우
+                                log.info("rtk 비정상, 재발급 불가");
+
+                                // 현재 rtk 쿠키 초기화
+                                refreshTokenId = "";
+
+                                // rtk 쿠키 삭제
+                                jwtTokenUtils.setInitTokenCookie("refreshTokenId", null, response);
+
+                                // 예외 처리(로그인 화면으로 이동)
+                                throw new CustomException(ErrorCode.NO_JWT_TOKEN);
+                            }
+                        } else {
+                            // rtk가 추출되지 않았다면 예외 처리(로그인 화면으로 이동)
+                            log.info("쿠키에 rtk 없음");
+                            throw new CustomException(ErrorCode.NO_JWT_TOKEN);
+                        }
+
+                    } else {
+                        // atk가 비정상적인 형태라면 예외 처리(로그인 화면으로 이동)
+                        log.info("atk 비정상 - 서명 등");
                         throw new CustomException(ErrorCode.NO_JWT_TOKEN);
                     }
-
-
-                    // 인증객체 생성
-                    SecurityContext context = SecurityContextHolder.createEmptyContext();
-                    String memberName = jwtTokenUtils.parseClaims(accessToken).getSubject();
-
-                    AbstractAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-                            MemberCreateRequest.builder()
-                                    .memberName(memberName)
-                                    .build(),
-                            accessToken, new ArrayList<>()
-                    );
-                    context.setAuthentication(authenticationToken);
-                    SecurityContextHolder.setContext(context);
                 }
+            } else {
+                // atk가 로그아웃된 토큰일 경우
+                log.info("로그아웃 됨");
+
+                // 현재 atk, rtk 초기화
+                accessToken = "";
+                refreshTokenId = "";
+
+                // atk, rtk 쿠키 삭제
+                jwtTokenUtils.setInitTokenCookie("accessToken", null, response);
+                jwtTokenUtils.setInitTokenCookie("refreshTokenId", null, response);
+
+                // 예외 처리(로그인 화면으로 이동)
+                throw new CustomException(ErrorCode.NO_JWT_TOKEN);
             }
+            // atk가 없고 rtk만 있을 경우
+        } else if (!refreshTokenId.equals("")) {
+            log.info("atk 없고 rtk만 있음");
 
-            /** accessToken이 존재하지 않고, refreshTokenId만 존재할 경우 */
-            else if(!refreshTokenId.equals("")) {
-                accessToken = jwtTokenUtils.reissue(refreshTokenId);
+            // atk 재발급
+            accessToken = jwtTokenUtils.reissue(refreshTokenId);
 
-                // 갱신한 accessToken이 유효한지 체크
-                if (!accessToken.equals("")) {
-                    // accessToken 재발급 후 쿠키, attribute에 저장
-                    jwtTokenUtils.setAtkCookie("accessToken", accessToken, response);
-                    request.setAttribute("accessToken", accessToken);
-                    log.info("accessToken 재발급 완료");
+            // atk 값이 비어있지 않은지 확인
+            // 재발급을 했는데도 불구하고 값이 비어있으면 rtk가 비정상인 것
+            if (!accessToken.equals("")) {
+                // atk가 정상
+                log.info("atk 재발급 완료");
 
-                    // 인증객체 생성
-                    SecurityContext context = SecurityContextHolder.createEmptyContext();
-                    String memberName = jwtTokenUtils.parseClaims(accessToken).getSubject();
+                // 쿠키에 저장
+                jwtTokenUtils.setAtkCookie("accessToken", accessToken, response);
 
-                    AbstractAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-                            MemberCreateRequest.builder()
-                                    .memberName(memberName)
-                                    .build(),
-                            accessToken, new ArrayList<>()
-                    );
-                    context.setAuthentication(authenticationToken);
-                    SecurityContextHolder.setContext(context);
-                }
+                // 인증객체 생성
+                SecurityContext context = SecurityContextHolder.createEmptyContext();
+                String memberName = jwtTokenUtils.parseClaims(accessToken).getSubject();
 
-                // refreshToken이 DB 상에 존재하지 않거나 유효하지 않는 경우 refreshToken 초기화
-                // (쿠키에는 있었으나 로직을 수행하는 사이 refreshToken의 유효시간이 지나서 DB에서 삭제된 경우)
-                else {
-                    refreshTokenId = "";
-                    log.info("refreshToken이 DB에 존재하지 않거나 유효하지 않음");
-                    throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
-                }
+                AbstractAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                        MemberCreateRequest.builder()
+                                .memberName(memberName)
+                                .build(),
+                        accessToken, new ArrayList<>()
+                );
+                context.setAuthentication(authenticationToken);
+                SecurityContextHolder.setContext(context);
+
+            } else {
+                // atk 값이 비어있을 경우
+                log.info("rtk 비정상, 재발급 불가");
+
+                // 현재 rtk 쿠키 초기화
+                refreshTokenId = "";
+
+                // rtk 쿠키 삭제
+                jwtTokenUtils.setInitTokenCookie("refreshTokenId", null, response);
+
+                // 예외 처리(로그인 화면으로 이동)
+                throw new CustomException(ErrorCode.NO_JWT_TOKEN);
             }
+        } else {
+            /*
+             * [쿠키에서 atk, rtk 모두 추출되지 않았다면 인증 절차를 거치지 않음]
+             * 권한이 필요한 api일 경우, 로그인 화면으로 이동
+             * 권한이 필요 없는 api일 경우, 화면 정상 출력
+             */
+            log.info("쿠키에 atk, rtk 모두 없음");
         }
+        log.info("필터 끝");
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/springles/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/springles/jwt/JwtTokenFilter.java
@@ -171,6 +171,11 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                                 // 쿠키에 저장
                                 jwtTokenUtils.setAtkCookie("accessToken", accessToken, response);
 
+                                // attribute에 저장
+                                // atk 재발급 후 쿠키에 저장해도 request 속 쿠키값은 변하지 않아 유효하지 않은 토큰으로 필터를 지나치게됨
+                                // 이를 해결하기 위해 재발급 시에만 request.setAttibute에도 atk 저장
+                                request.setAttribute("accessToken", accessToken);
+
                                 // 인증객체 생성
                                 SecurityContext context = SecurityContextHolder.createEmptyContext();
                                 String memberName = jwtTokenUtils.parseClaims(accessToken).getSubject();
@@ -239,6 +244,11 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
                 // 쿠키에 저장
                 jwtTokenUtils.setAtkCookie("accessToken", accessToken, response);
+
+                // attribute에 저장
+                // atk 재발급 후 쿠키에 저장해도 request 속 쿠키값은 변하지 않아 유효하지 않은 토큰으로 필터를 지나치게됨
+                // 이를 해결하기 위해 재발급 시에만 request.setAttibute에도 atk 저장
+                request.setAttribute("accessToken", accessToken);
 
                 // 인증객체 생성
                 SecurityContext context = SecurityContextHolder.createEmptyContext();

--- a/src/main/java/com/springles/jwt/JwtTokenUtils.java
+++ b/src/main/java/com/springles/jwt/JwtTokenUtils.java
@@ -178,6 +178,7 @@ public class JwtTokenUtils {
         if(cookies.length != 0) {
             log.info("utils: 쿠키 있음");
             for (Cookie cookie : cookies) {
+                // 쿠키에 accessToken이 있는지 확인
                 if ("accessToken".equals(cookie.getName())) {
                     log.info("utils: accessToken 있음");
                     accessToken = cookie.getValue();
@@ -185,9 +186,9 @@ public class JwtTokenUtils {
                     break;
                 }
             }
+            // 쿠키에 accessToken이 없으면 request.attribute에서 추출
             if(accessToken.equals("")) {
-                log.info("utils: accessToken 없음");
-                throw new CustomException(ErrorCode.NOT_AUTHORIZED_CONTENT);
+                accessToken = String.valueOf(request.getAttribute("accessToken"));
             }
         } else {
             throw new CustomException(ErrorCode.NOT_AUTHORIZED_CONTENT);

--- a/src/main/java/com/springles/jwt/JwtTokenUtils.java
+++ b/src/main/java/com/springles/jwt/JwtTokenUtils.java
@@ -155,7 +155,7 @@ public class JwtTokenUtils {
         cookie.setPath("/");
         cookie.setMaxAge(60 * 60);  // 테스트용 1시간
         cookie.setHttpOnly(true);
-        cookie.setSecure(true);
+//        cookie.setSecure(true);   // 사파리 브라우저에서 쿠키 저장이 안되는 이슈 해결을 위해 설정 해제
         response.addCookie(cookie);
     }
 
@@ -166,7 +166,7 @@ public class JwtTokenUtils {
         cookie.setPath("/");
         cookie.setMaxAge(0);
         cookie.setHttpOnly(true);
-        cookie.setSecure(true);
+//        cookie.setSecure(true);   // 사파리 브라우저에서 쿠키 저장이 안되는 이슈 해결을 위해 설정 해제
         response.addCookie(cookie);
     }
 

--- a/src/main/java/com/springles/jwt/JwtTokenUtils.java
+++ b/src/main/java/com/springles/jwt/JwtTokenUtils.java
@@ -9,6 +9,7 @@ import com.springles.repository.RefreshTokenRedisRepository;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -74,14 +75,17 @@ public class JwtTokenUtils {
         Optional<RefreshToken> optionalRefreshToken = refreshTokenRedisRepository.findById(refreshTokenId);
         if(optionalRefreshToken.isEmpty()) {
             log.warn("refresh token이 DB에 존재하지 않음");
-//            throw new CustomException(ErrorCode.NO_JWT_TOKEN);
+
             return "";
         }
 
         // refreshToken이 유효한지 확인
         if(!memberJpaRepository.existsByMemberName(optionalRefreshToken.get().getMemberName())) {
             log.warn("refresh token이 유효하지 않음");
-//            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+
+            // DB에서 refreshToken 삭제
+            refreshTokenRedisRepository.deleteById(refreshTokenId);
+
             return "";
         }
 
@@ -125,6 +129,9 @@ public class JwtTokenUtils {
         } catch (IllegalArgumentException e) {
             log.warn("잘못된 JWT 토큰");
             return 0;
+        } catch (Exception e) {
+            log.warn(e.getMessage());
+            return 0;
         }
     }
 
@@ -150,5 +157,41 @@ public class JwtTokenUtils {
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         response.addCookie(cookie);
+    }
+
+    // Token 쿠키 초기화 설정
+    public void setInitTokenCookie(String name, String value, HttpServletResponse response) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setDomain("localhost");
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        response.addCookie(cookie);
+    }
+
+    // 쿠키에서 accessToken 호출
+    public String atkFromCookie(HttpServletRequest request) {
+        String accessToken = "";
+        Cookie[] cookies = request.getCookies();
+
+        if(cookies.length != 0) {
+            log.info("utils: 쿠키 있음");
+            for (Cookie cookie : cookies) {
+                if ("accessToken".equals(cookie.getName())) {
+                    log.info("utils: accessToken 있음");
+                    accessToken = cookie.getValue();
+                    log.info("utils: " + accessToken);
+                    break;
+                }
+            }
+            if(accessToken.equals("")) {
+                log.info("utils: accessToken 없음");
+                throw new CustomException(ErrorCode.NOT_AUTHORIZED_CONTENT);
+            }
+        } else {
+            throw new CustomException(ErrorCode.NOT_AUTHORIZED_CONTENT);
+        }
+        return accessToken;
     }
 }


### PR DESCRIPTION
## 🌿 PR타입
- [ ] 기능 추가
- [v] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
index페이지 접근 시, 로그아웃 시 리다이렉트가 발생되는 이슈 해결을 위해 JwtTokenFilter 로직 수정
### 📑 개요

###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
def0e76:bug:  jwtTokenFilter 로직 수정

9384016 :bug: wtTokenUtils 메소드 추가/수정
- cookie 초기화 메소드 추가
- reissue메소드 로직 수행 시 refreshTokenId가 유효하지 않을 경우 db에서 삭제되도록 코드 추가
- cookie에서 accessToken 추출하는 메소드 추가(controller, service에서 accessToken 호출하기 위함)
- validation메소드에 excption추가

e3ad58e :bug: controller에서의 accessToken 호출 로직을 request.attribute -> cookie로 변경 

784aeb8 :bug: 로그인, 회원가입, 아이디/비밀번호 찾기를 제외한 나머지 api에 authenticated 권한 부여

bb6f44f :bug: accessToken 재발급 시 토큰이 쿠키와 request.attribute 모두에 저장되도록 변경
- accessToken 재발급 시 갱신된 토큰이 쿠키에 저장은 되지만 수행하고 있던 request 요청 속 쿠키 값은 변하지 않아 
기존 토큰(유효하지 않은 토큰)으로 필터를 지나치게 된다는 이슈가 있음.
이를 해결하기 위해 재발급 시에만 request.setAttibute에도 accessToken을 저장함

e56a39f :bug: 쿠키 secure 설정 해제
- 사파리에서 토큰이 저장되지 않는 이슈 해결을 위함
* secure 설정이 된 쿠키는 https에서만  저장이 되어야 하지만 개발 편의를 위해 localhost는 예외적으로 http에서도 저장이 되도록 대부분의 브라우저에서 편의를 봐주고 있는 거라고 합니다. 
원인이 정말 secure 설정 때문일지는 모르겠지만 우선 설정 해제 해두었습니다.
*참고 url) https://shanepark.tistory.com/454


## 📷 스크린샷

## 👀 기타
jwtTokenFilter 코드는 정리라곤 되지 않은 날 것 그대로의 코드입니다....ㅎㅎ
오류를 최소화하기 위해 로직을 촘촘하게 짜는 걸 목적으로 구현해보았습니다.
혹시 오류가 발생한다면.. 언제든지 모른ㅊ...^_^ 이 아니라 꼭 알려주세요!!