### PR TITLE
Fix/#239-accessToken-reissue-cookie-save-error

### DIFF
--- a/src/main/java/com/springles/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/springles/jwt/JwtTokenFilter.java
@@ -109,6 +109,11 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                                         CookieSetRequest.builder().key("accessToken").value(accessToken).build(), response);
                                 log.info("atk 쿠키에 저장 완료");
 
+                                // attribute에 저장
+                                // atk 재발급 후 쿠키에 저장해도 request 속 쿠키값은 변하지 않아 유효하지 않은 토큰으로 필터를 지나치게됨
+                                // 이를 해결하기 위해 재발급 시에만 request.setAttibute에도 atk 저장
+                                request.setAttribute("accessToken", accessToken);
+
                             } else {
                                 // atk 값이 비어있을 경우
                                 log.info("rtk 비정상, 재발급 불가");
@@ -252,7 +257,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                 log.info("atk 재발급 완료");
 
                 // 쿠키에 저장
-                cookieService.setInitCookie(
+                cookieService.setAtkCookie(
                         CookieSetRequest.builder().key("accessToken").value(accessToken).build(), response);
 
                 // attribute에 저장


### PR DESCRIPTION
## 🌿 PR타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
accessToken 재발급 시 쿠키에 저장이 안되는 오류 발생
### 📑 개요
###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
41d2e5e refreshTokenId만 있을 경우 accessToken 재발급 시 쿠키 저장 메소드를 setinitCookie() -> setAtkCookie()로 수정
- +)추가로, accessToken 유효기간이 얼마 남지 않아서 재발급 될 경우 reuqest attribute에도 저장되도록 코드 추가

## 📷 스크린샷

## 👀 기타
