### PR TITLE
:bug: fix: 투표 리스트가 비어있을 떄 게임이 진행되지 않던 버그 수정

### DIFF
--- a/src/main/java/com/springles/game/DayDiscussionManager.java
+++ b/src/main/java/com/springles/game/DayDiscussionManager.java
@@ -47,8 +47,6 @@ public class DayDiscussionManager {
                 message.getSuspiciousList();
 
         log.info("Room {} suspicious List: {}", roomId, suspiciousList.toString());
-        log.info(String.valueOf(suspiciousList.isEmpty()));
-        Optional<Player> deadPlayerOptional = playerRedisRepository.findById(suspiciousList.get(0));
         if (suspiciousList.isEmpty()) {
             log.info("Room {} suspicious List is Empty", roomId);
             messageManager.sendMessage(
@@ -62,6 +60,7 @@ public class DayDiscussionManager {
             return;
         }
         else {
+            Optional<Player> deadPlayerOptional = playerRedisRepository.findById(suspiciousList.get(0));
             Player deadPlayer = deadPlayerOptional.get();
             log.info("{}가 마피아로 지목되었습니다.", deadPlayer.getMemberName());
             messageManager.sendMessage(


### PR DESCRIPTION
## 🌿 PR타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
close #268 

###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- 817d673ab3fbb50e3a2deb64839a6c40ed0ed418 : 투표 리스트가 비어있을 때 지목 대상자 플레이어를 조회하기 위해 list의 0번 인덱스를 사용하던 코드를 if문으로 옮겼습니다.

## 📷 스크린샷

## 👀 기타
