### PR TITLE
Fix/#285 chatroom add valid sequence

### DIFF
--- a/src/main/java/com/springles/controller/api/ChatRoomController.java
+++ b/src/main/java/com/springles/controller/api/ChatRoomController.java
@@ -10,6 +10,7 @@ import com.springles.domain.dto.response.ResResult;
 import com.springles.game.GameSessionManager;
 import com.springles.service.ChatRoomService;
 import com.springles.service.CookieService;
+import com.springles.valid.ValidationSequence;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.Authentication;
 
@@ -36,7 +38,7 @@ public class ChatRoomController {
     // 채팅방 생성
     @Operation(summary = "채팅방 생성", description = "채팅방 생성")
     @PostMapping(value = "/chatrooms")
-    public ResponseEntity<ResResult> createChatRoom(@Valid @RequestBody ChatRoomReqDTO chatRoomReqDTO, HttpServletRequest request, Authentication auth) {
+    public ResponseEntity<ResResult> createChatRoom(@Validated({ValidationSequence.class}) @RequestBody ChatRoomReqDTO chatRoomReqDTO, HttpServletRequest request, Authentication auth) {
 
         String accessToken = cookieService.atkFromCookie(request);
         MemberInfoResponse info = memberUiController.info(accessToken);

--- a/src/main/java/com/springles/domain/dto/chatroom/ChatRoomReqDTO.java
+++ b/src/main/java/com/springles/domain/dto/chatroom/ChatRoomReqDTO.java
@@ -3,6 +3,7 @@ package com.springles.domain.dto.chatroom;
 
 import com.springles.domain.constants.ChatRoomCode;
 import com.springles.domain.entity.ChatRoom;
+import com.springles.valid.ValidationGroups;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Data;
@@ -10,18 +11,18 @@ import lombok.Data;
 
 @Data
 public class ChatRoomReqDTO {
-    @NotBlank(message = "방 제목은 필수입니다.")
-    @Size(min = 4, max = 15, message = "방 제목은 4자 이상 15자 이하여야 합니다.")
+    @NotBlank(message = "방 제목은 필수입니다.##", groups = ValidationGroups.NotEmptyGroup.class)
+    @Size(min = 4, max = 15, message = "방 제목은 4자 이상 15자 이하여야 합니다.##", groups = ValidationGroups.SizeCheckGroup.class)
     @Schema(description = "제목")
     private String title;
 
-    @Max(value = 10, message = "방 인원은 10명 이하이여야 합니다.")
-    @Min(value = 5, message = "방 인원은 5명 이상이여야 합니다.")
-    @NotNull(message = "방 인원은 필수입니다.")
+    @Max(value = 10, message = "방 인원은 10명 이하이여야 합니다.##", groups = ValidationGroups.SizeCheckGroup.class)
+    @Min(value = 5, message = "방 인원은 5명 이상이여야 합니다.##", groups = ValidationGroups.SizeCheckGroup.class)
+    @NotNull(message = "방 인원은 필수입니다.##", groups = ValidationGroups.NotEmptyGroup.class)
     @Schema(description = "정원")
     private Long capacity;
 
-    @NotNull(message = "방 상태는 필수입니다.")
+    @NotNull(message = "방 상태는 필수입니다.##", groups = ValidationGroups.NotEmptyGroup.class)
     @Schema(description = "상태")
     private Boolean close;
 

--- a/src/main/resources/templates/home/add.html
+++ b/src/main/resources/templates/home/add.html
@@ -92,7 +92,7 @@
                             location.replace('http://localhost:8080/v1/chat/'+ roomId + '/' + nickName);
                         },
                         error: function(response) {
-                            alert(JSON.stringify(response.responseJSON.message))
+                            alert((response.responseJSON.message).split('##')[0])
                         },
                     });
                 });


### PR DESCRIPTION
## 🌿 PR타입
- [ ] 기능 추가
- [v] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
### 📑 개요
채팅방 생성 화면에서 입력값에 대한 valid 체크 시 우선순위 없이 모든 오류 문구가 출력되고 있어 하나씩 노출될 수 있도록 수정

as-is: 방 제목, 방 인원 모두 미입력 시 '방 제목은 필수 입니다', '방 인원은 필수입니다' 문구가 모두 노출됨
to-be: 방 제목, 방 인원 모두 미입력 시 우선적으로 '방 제목은 필수입니다' 문구만 노출됨
###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- eacc125 ChatRoomReqDTO, ChatroomController에 valid sequence 적용
- 40241c0 add.html에 오류문구가 우선순위 가장 높은 문구만 출력되도록 수정

## 📷 스크린샷
모든 입력값 미입력 후 등록버튼 클릭 시 오류문구 하나만 출력됨
![image](https://github.com/Techit-Springles/Backend/assets/126767770/7444b0ef-09ab-4f5f-aaea-f34fdedf6b69)


## 👀 기타
