### PR TITLE
:bug: fix: 직업별 메시지 수신 시 메시지 처리 로직 추가

### DIFF
--- a/src/main/java/com/springles/controller/message/MessageController.java
+++ b/src/main/java/com/springles/controller/message/MessageController.java
@@ -40,10 +40,12 @@ public class MessageController {
     public void sendMessage(SimpMessageHeaderAccessor accessor, String message,
         @DestinationVariable Long roomId) {
 
-        log.info("수신 메시지: " + message + " 방 id: " + roomId + " 발송자: " + getMemberName(accessor));
 
         GameSession gameSession = gameSessionManager.findGameByRoomId(roomId);
         Player player = gameSessionManager.findPlayerByMemberName(getMemberName(accessor));
+
+        log.info("수신 메시지: " + message + " 방 id: " + roomId + " 발송자: " + getMemberName(accessor) + "페이즈: " + gameSession.getGamePhase());
+
         // 관전자는 관전자들끼리만 채팅이 가능
         if (player.getRole().equals(GameRole.OBSERVER)) {
             messageManager.sendMessage("/sub/chat/" + roomId + "/" + GameRole.OBSERVER, message,

--- a/src/main/resources/templates/chat-room.html
+++ b/src/main/resources/templates/chat-room.html
@@ -401,9 +401,11 @@
                 // 게임 시작 시 역할 부여 URL 구독
                 stompClient.subscribe(`/sub/chat/${roomId}/gameRole/${nickname}`, (message => {
                     const body = JSON.parse(message.body)
-                    console.log("역할 설명 메시지: " + body)
-                    stompClient.subscribe(`/sub/chat/${roomId}/${body.gameRole}`) // 직업 url
-                    stompClient.unsubscribe(`/sub/chat/${roomId}/playerRole/${nickname}`)
+                    console.log("역할 설명 메시지: ")
+                    stompClient.subscribe(`/sub/chat/${roomId}/${body.gameRole}`, message => {
+                        receiveMessage(JSON.parse(message.body))
+                    }) // 직업 url
+                    stompClient.unsubscribe(`/sub/chat/${roomId}/gameRole/${nickname}`)
                     receiveMessage(body)
                     // 내 직업 정보 팝업에 플레이어별 부여된 역할에 맞는 내용 출력
                     inGameRole = body.gameRole


### PR DESCRIPTION
## 🌿 PR타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]

Closes #306 

### 📑 개요
직업별 메시지 url을 구독할 때 메시지 수신 후 처리 로직을 구현하지 않았던 사항을 수정했습니다.
